### PR TITLE
fix(scripts): address copy mode update edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to agentic-config.
 
 ## [Unreleased]
 
+### Fixed
+
+- New agentic-*.md agents now installed for copy mode users during update (previously only existing agents were updated)
+- SPEC_ARG with spaces now handled correctly in `/full-life-cycle-pr` (quoted strings parsed properly)
+- Version tracking now always updates when copy mode replaces assets (previously could skip if template changes pending)
+- Backup verification for agents/ now validates file count (not just directory existence) to catch partial backups
+- Invalid INSTALL_MODE values now rejected with clear error message during update
+- Documentation inconsistency in `/milestone` (removed `--no-tag` alias, only `--skip-tag` supported)
+- Dry-run output in `setup-config.sh` now shows copy mode indicator
+
 ## [0.1.7] - 2025-12-17
 
 ### Added

--- a/core/commands/claude/milestone.md
+++ b/core/commands/claude/milestone.md
@@ -35,7 +35,7 @@ Parse `$ARGUMENTS` into:
 **Parsing Rules:**
 - If an argument starts and ends with `"`, treat as `VALIDATION_PROMPT`
 - Version is optional; if 4th arg is quoted, there's no version
-- If `--skip-tag` or `--no-tag` flag is present anywhere in arguments, set `SKIP_TAG=true`
+- If `--skip-tag` flag is present anywhere in arguments, set `SKIP_TAG=true`
 - Empty `$ARGUMENTS` triggers full auto-detect mode
 
 ## Phase 0: Smart Defaults Resolution

--- a/scripts/setup-config.sh
+++ b/scripts/setup-config.sh
@@ -137,6 +137,8 @@ TARGET_PATH="$(cd "$TARGET_PATH" && pwd)"
 
 echo "Agentic Configuration Setup v$VERSION"
 echo "   Target: $TARGET_PATH"
+[[ "$COPY_MODE" == true ]] && echo "   Mode: copy"
+[[ "$DRY_RUN" == true ]] && echo "   (DRY RUN)"
 
 # Auto-detect project type if not specified
 if [[ -z "$PROJECT_TYPE" ]]; then


### PR DESCRIPTION
## Summary

- Fixes 4 MEDIUM + 3 LOW severity issues identified in PR #1 review
- Addresses copy mode update edge cases for better reliability
- Improves argument parsing and validation across scripts

## Changes

### update-config.sh
- **New agents for copy mode**: New `agentic-*.md` agents now installed during update (not just existing ones updated)
- **INSTALL_MODE validation**: Invalid values rejected with clear error message
- **Version tracking**: Always updates when copy mode replaces assets
- **Backup verification**: Now validates file count (not just directory existence)

### full-life-cycle-pr.md
- **SPEC_ARG parsing**: Properly handles quoted strings with spaces (e.g., `"Add new feature"`)

### setup-config.sh
- **Dry-run output**: Now shows copy mode indicator

### milestone.md
- **Documentation fix**: Removed `--no-tag` alias (only `--skip-tag` supported)

## Test Plan

- [ ] Run `update-config.sh` on copy mode installation and verify new agents are installed
- [ ] Run `/full-life-cycle-pr branch-name "spec with spaces" lean` and verify SPEC_ARG parsed correctly
- [ ] Run `setup-config.sh --dry-run --copy /path` and verify mode shown in output
- [ ] Verify `update-config.sh` with invalid INSTALL_MODE in config rejects with error

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)