### PR TITLE
FIX: make UUID generation POSIX-safe across Bash commands

### DIFF
--- a/core/commands/claude/fork-terminal.md
+++ b/core/commands/claude/fork-terminal.md
@@ -94,7 +94,7 @@ osascript -e 'tell application "kitty" to activate' \
 ## VARIABLES
 
 # Generate UUID if WORK_PATH not provided
-UUID=$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)
+UUID=`uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8`
 DEFAULT_PATH="/tmp/claude/${UUID}"
 WORK_PATH=${1:-$DEFAULT_PATH}
 

--- a/core/commands/claude/o_spec.md
+++ b/core/commands/claude/o_spec.md
@@ -170,7 +170,7 @@ done
 
 2. If starting fresh, create session directory and state file:
 ```bash
-SESSION_UUID=$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)
+SESSION_UUID=`uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8`
 SESSION_ID="$(date +%H%M%S)-${SESSION_UUID}"
 SESSION_DIR="outputs/orc/$(date +%Y/%m/%d)/${SESSION_ID}"
 mkdir -p "$SESSION_DIR"

--- a/core/commands/claude/po_spec.md
+++ b/core/commands/claude/po_spec.md
@@ -163,7 +163,7 @@ If found and user passed new input: ask to resume existing or start fresh.
 
 1. Create session directory:
 ```bash
-SESSION_UUID=$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)
+SESSION_UUID=`uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8`
 SESSION_ID="$(date +%H%M%S)-${SESSION_UUID}"
 SESSION_DIR="outputs/phases/$(date +%Y/%m/%d)/${SESSION_ID}"
 mkdir -p "$SESSION_DIR"

--- a/core/commands/claude/worktree.md
+++ b/core/commands/claude/worktree.md
@@ -127,7 +127,7 @@ This command MUST execute ALL steps (1-8) in sequence WITHOUT stopping for user 
 ### Step 1: Generate unique name
 
 ```bash
-UUID_PREFIX=$(uuidgen | cut -c1-6 | tr '[:upper:]' '[:lower:]')
+UUID_PREFIX=`uuidgen | cut -c1-6 | tr '[:upper:]' '[:lower:]'`
 FULL_NAME="$UUID_PREFIX-<worktree_name>"
 ```
 

--- a/core/skills/agent-orchestrator-manager/SKILL.md
+++ b/core/skills/agent-orchestrator-manager/SKILL.md
@@ -196,7 +196,7 @@ These functions describe behavior for AI agents to implement when managing workf
 
 Create new session directory and `workflow_state.yml`:
 1. Generate `SESSION_UUID` using `uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8`
-2. Generate `SESSION_ID` as `$(date +%H%M%S)-${SESSION_UUID}`
+2. Generate `SESSION_ID` as ``date +%H%M%S``-${SESSION_UUID}
 3. Create dir: `outputs/orc/$(date +%Y/%m/%d)/${SESSION_ID}/`
 4. Write initial state with: `status: "in_progress"`, `current_step: 1`, `current_step_status: "pending"`, `steps: []`
 


### PR DESCRIPTION
This PR fixes a shell parsing issue caused by Bash-only command substitution
(`$(...)`) used for UUID generation in several command definitions.

These commands are executed via an eval-style shell runner that does not
guarantee Bash, which can lead to parse errors like:
    (eval):1: parse error near '('

To make execution consistent and POSIX-safe, UUID generation now uses
backtick-based command substitution across all affected commands.
Behavior, UUID format, and length remain unchanged.

Scope is intentionally limited to UUID-related logic only.
