### PR TITLE
fix(spec): enforce spec(NNN): prefix on all IMPLEMENT commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to agentic-config.
 
 ## [Unreleased]
 
+### Fixed
+
+- IMPLEMENT spec stage now enforces `spec(NNN): IMPLEMENT - <title>` format on ALL commits (was missing on first commit)
+
 ## [0.1.14] - 2025-12-26
 
 ### Added

--- a/core/agents/spec/IMPLEMENT.md
+++ b/core/agents/spec/IMPLEMENT.md
@@ -26,9 +26,9 @@ SPEC: $ARGUMENT
 6. IF an unexpected error/failure occurs, surface it to the user. If you cannot recover from it, stop and ask user feedback. DO NOT ignore the error/failure.
 7. SUMMARIZE result to user in output (max: 150 words).
 8. COMMIT implementation, tests, and spec (ONLY the files you changed):
-	1. Commit code changes + tests + spec file with task statuses
+	1. Commit code changes + tests + spec file with task statuses using message: `spec(NNN): IMPLEMENT - <title>`
 	2. Update spec with commit hash, placing it clearly at the end of the '# AI Section > ## Implement' section.
-	3. Commit spec file again with message: `spec(NNN): IMPLEMENT - <title>`
+	3. Commit spec file again with message: `spec(NNN): IMPLEMENT - <title> [hash]`
 
 ## Behavior
 


### PR DESCRIPTION
## Summary

Fixes inconsistent commit message format in the IMPLEMENT spec stage. Previously, the first commit (code+tests+spec) lacked the `spec(NNN): IMPLEMENT - <title>` format specification, while only the second commit had it. This caused validation failures in o_spec orchestration.

- Enforces `spec(NNN): IMPLEMENT - <title>` format on BOTH commits in IMPLEMENT workflow
- Aligns IMPLEMENT stage with all other spec stages (CREATE, RESEARCH, PLAN, etc.)

### Root Cause

The IMPLEMENT.md agent definition (line 29) described committing code changes without specifying the required commit format, leading to agents using arbitrary formats like `feat(...)` instead of the expected `spec(NNN): IMPLEMENT - <title>`.

### Key Changes

**core/agents/spec/IMPLEMENT.md:**
- Line 29: Added explicit `spec(NNN): IMPLEMENT - <title>` format for first commit (code+tests+spec)
- Line 31: Differentiated second commit with `[hash]` suffix: `spec(NNN): IMPLEMENT - <title> [hash]`

## Test Plan

- [x] Verified all 15 spec stage files now use consistent `spec(NNN): <STAGE> - <title>` format
- [x] Validated markdown syntax in IMPLEMENT.md
- [x] Run an o_spec workflow to verify commit format validation passes

## Files Changed

**Agent Definition:**
- `core/agents/spec/IMPLEMENT.md` - Added explicit commit format to step 8.1 and 8.3

**Documentation:**
- `CHANGELOG.md` - Added fix entry to [Unreleased]

Generated with [Claude Code](https://claude.com/claude-code)