### PR TITLE
docs(templates): add Conditional Documentation for external specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to agentic-config.
 
 ## [Unreleased]
 
+### Added
+
+- Conditional Documentation section in all AGENTS.md templates referencing `$AGENTIC_GLOBAL/docs/external-specs-storage.md`
+  - Guides users to external specs documentation when configuring spec storage
+  - Applies to all 7 project type templates (generic, python-*, rust, typescript, ts-bun)
+
 ## [0.1.15] - 2026-01-03
 
 ### Added

--- a/templates/generic/AGENTS.md.template
+++ b/templates/generic/AGENTS.md.template
@@ -59,6 +59,15 @@ source "$AGENTIC_GLOBAL/core/lib/spec-resolver.sh"
 - From main's linear history perspective, unreleased changes are ONE logical unit
 - Do NOT add "Fixed" entries for implementation iterations before merge to main
 
+## Conditional Documentation
+
+Read documentation only when relevant to your task:
+
+- **`$AGENTIC_GLOBAL/docs/external-specs-storage.md`** - When:
+  - Configuring external specs repository
+  - Working with `/spec`, `/o_spec`, `/po_spec`, or `/branch` commands
+  - Modifying spec path resolution or commit routing
+
 ## Project-Specific Instructions
 READ @PROJECT_AGENTS.md for project-specific instructions - CRITICAL COMPLIANCE
 

--- a/templates/python-pip/AGENTS.md.template
+++ b/templates/python-pip/AGENTS.md.template
@@ -60,6 +60,15 @@ source "$AGENTIC_GLOBAL/core/lib/spec-resolver.sh"
 - From main's linear history perspective, unreleased changes are ONE logical unit
 - Do NOT add "Fixed" entries for implementation iterations before merge to main
 
+## Conditional Documentation
+
+Read documentation only when relevant to your task:
+
+- **`$AGENTIC_GLOBAL/docs/external-specs-storage.md`** - When:
+  - Configuring external specs repository
+  - Working with `/spec`, `/o_spec`, `/po_spec`, or `/branch` commands
+  - Modifying spec path resolution or commit routing
+
 ## Project-Specific Instructions
 READ @PROJECT_AGENTS.md for project-specific instructions - CRITICAL COMPLIANCE
 

--- a/templates/python-poetry/AGENTS.md.template
+++ b/templates/python-poetry/AGENTS.md.template
@@ -60,6 +60,15 @@ source "$AGENTIC_GLOBAL/core/lib/spec-resolver.sh"
 - From main's linear history perspective, unreleased changes are ONE logical unit
 - Do NOT add "Fixed" entries for implementation iterations before merge to main
 
+## Conditional Documentation
+
+Read documentation only when relevant to your task:
+
+- **`$AGENTIC_GLOBAL/docs/external-specs-storage.md`** - When:
+  - Configuring external specs repository
+  - Working with `/spec`, `/o_spec`, `/po_spec`, or `/branch` commands
+  - Modifying spec path resolution or commit routing
+
 ## Project-Specific Instructions
 READ @PROJECT_AGENTS.md for project-specific instructions - CRITICAL COMPLIANCE
 

--- a/templates/python-uv/AGENTS.md.template
+++ b/templates/python-uv/AGENTS.md.template
@@ -60,6 +60,15 @@ source "$AGENTIC_GLOBAL/core/lib/spec-resolver.sh"
 - From main's linear history perspective, unreleased changes are ONE logical unit
 - Do NOT add "Fixed" entries for implementation iterations before merge to main
 
+## Conditional Documentation
+
+Read documentation only when relevant to your task:
+
+- **`$AGENTIC_GLOBAL/docs/external-specs-storage.md`** - When:
+  - Configuring external specs repository
+  - Working with `/spec`, `/o_spec`, `/po_spec`, or `/branch` commands
+  - Modifying spec path resolution or commit routing
+
 ## Project-Specific Instructions
 READ @PROJECT_AGENTS.md for project-specific instructions - CRITICAL COMPLIANCE
 

--- a/templates/rust/AGENTS.md.template
+++ b/templates/rust/AGENTS.md.template
@@ -60,6 +60,15 @@ source "$AGENTIC_GLOBAL/core/lib/spec-resolver.sh"
 - From main's linear history perspective, unreleased changes are ONE logical unit
 - Do NOT add "Fixed" entries for implementation iterations before merge to main
 
+## Conditional Documentation
+
+Read documentation only when relevant to your task:
+
+- **`$AGENTIC_GLOBAL/docs/external-specs-storage.md`** - When:
+  - Configuring external specs repository
+  - Working with `/spec`, `/o_spec`, `/po_spec`, or `/branch` commands
+  - Modifying spec path resolution or commit routing
+
 ## Project-Specific Instructions
 READ @PROJECT_AGENTS.md for project-specific instructions - CRITICAL COMPLIANCE
 

--- a/templates/ts-bun/AGENTS.md.template
+++ b/templates/ts-bun/AGENTS.md.template
@@ -60,6 +60,15 @@ source "$AGENTIC_GLOBAL/core/lib/spec-resolver.sh"
 - From main's linear history perspective, unreleased changes are ONE logical unit
 - Do NOT add "Fixed" entries for implementation iterations before merge to main
 
+## Conditional Documentation
+
+Read documentation only when relevant to your task:
+
+- **`$AGENTIC_GLOBAL/docs/external-specs-storage.md`** - When:
+  - Configuring external specs repository
+  - Working with `/spec`, `/o_spec`, `/po_spec`, or `/branch` commands
+  - Modifying spec path resolution or commit routing
+
 ## Project-Specific Instructions
 READ @PROJECT_AGENTS.md for project-specific instructions - CRITICAL COMPLIANCE
 

--- a/templates/typescript/AGENTS.md.template
+++ b/templates/typescript/AGENTS.md.template
@@ -60,6 +60,15 @@ source "$AGENTIC_GLOBAL/core/lib/spec-resolver.sh"
 - From main's linear history perspective, unreleased changes are ONE logical unit
 - Do NOT add "Fixed" entries for implementation iterations before merge to main
 
+## Conditional Documentation
+
+Read documentation only when relevant to your task:
+
+- **`$AGENTIC_GLOBAL/docs/external-specs-storage.md`** - When:
+  - Configuring external specs repository
+  - Working with `/spec`, `/o_spec`, `/po_spec`, or `/branch` commands
+  - Modifying spec path resolution or commit routing
+
 ## Project-Specific Instructions
 READ @PROJECT_AGENTS.md for project-specific instructions - CRITICAL COMPLIANCE
 


### PR DESCRIPTION
## Summary

- Add Conditional Documentation section to all 7 AGENTS.md templates
- Reference `$AGENTIC_GLOBAL/docs/external-specs-storage.md` for external specs configuration
- Enables discoverability of external specs feature for users

## Test plan

- [x] Verify new section appears in all templates
- [x] Run `/agentic setup` on test project and confirm AGENTS.md includes new section
- [x] Verify `$AGENTIC_GLOBAL` path resolves correctly

Generated with Claude Code