### PR TITLE
feat(mux): add watchdog health check for subagent liveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to agentic-config.
 
 ## [Unreleased]
 
+### Added
+
+- `ac-workflow` (mux): watchdog health check for subagent liveness monitoring
+  - ~10-minute timeout triggers TaskOutput liveness probe on silent subagents
+  - Dead agents automatically relaunched fresh (max 2 retries per task)
+  - Running agents are never forcefully killed — health check only
+  - Applied to `mux`, `mux-ospec`, and `mux-roadmap` skills
+  - `mux-orchestrator-guard.py` updated to allow TaskOutput for watchdog (previously unconditionally blocked)
+
 ## [0.2.5] - 2026-03-20
 
 ### Added

--- a/plugins/ac-workflow/skills/mux-ospec/SKILL.md
+++ b/plugins/ac-workflow/skills/mux-ospec/SKILL.md
@@ -484,7 +484,7 @@ uv run ${CLAUDE_PLUGIN_ROOT}/skills/mux/tools/check-signals.py $DIR --expected N
 | Scenario | Action |
 |----------|--------|
 | CREATE fails | Escalate to user - spec path or prompt may need adjustment |
-| Stage agent timeout | If no task-notification after extended time, run verify.py to check signals. If worker truly stuck, mark STAGE_FAILED, launch fresh agent |
+| Stage agent timeout | **Watchdog protocol**: after ~10min with no task-notification, call TaskOutput on the background task as a liveness probe. If agent alive, wait. If agent dead, relaunch fresh (max 2 retries). See MUX SKILL.md WATCHDOG HEALTH CHECK section. |
 | Skill(spec) internal failure | Stage agent returns STAGE_FAILED with error details |
 | Type check fails 3x | STAGE_FAILED with error details, escalate to user |
 | Tests fail 3x | STAGE_FAILED with failure analysis, escalate to user |
@@ -492,6 +492,23 @@ uv run ${CLAUDE_PLUGIN_ROOT}/skills/mux/tools/check-signals.py $DIR --expected N
 | Review cycle WARN/FAIL after max cycles | STAGE_FAILED. Escalate to user - ONLY PASS proceeds |
 | Signal file missing after "done" | Treat as STAGE_FAILED, relaunch fresh agent |
 | Skill permission denied | Subagent returns PERMISSION_DENIED. Escalate to user: "Background agents cannot surface permission prompts. Run Claude Code with `--dangerously-skip-permissions` or add `Skill` to allowed tools in `.claude/settings.json`" |
+
+## WATCHDOG HEALTH CHECK
+
+This skill inherits the MUX watchdog protocol. Full specification: `${CLAUDE_PLUGIN_ROOT}/skills/mux/SKILL.md` > WATCHDOG HEALTH CHECK section.
+
+**Quick reference for stage agents:**
+
+After dispatching ANY stage agent (CREATE, GATHER, CONSOLIDATE, PLAN, IMPLEMENT, REVIEW, FIX, TEST, DOCUMENT, SENTINEL):
+
+1. End your turn and wait for task-notification (normal flow)
+2. If ~10 minutes pass with no task-notification AND no signal file:
+   - Call `TaskOutput` on the background task as a liveness probe
+   - Agent still running → do nothing, check again after another ~10 min
+   - Agent terminated/dead → relaunch FRESH agent with same prompt (max 2 retries)
+3. If max retries exhausted → STAGE_FAILED, escalate to user
+
+**CRITICAL**: The timeout is a health check trigger, NEVER a kill signal. The orchestrator NEVER forcefully terminates a running agent.
 
 ## SESSION CLEANUP
 

--- a/plugins/ac-workflow/skills/mux-ospec/cookbook/error-recovery.md
+++ b/plugins/ac-workflow/skills/mux-ospec/cookbook/error-recovery.md
@@ -17,7 +17,13 @@ Handling failures in the o_spec workflow via MUX orchestration.
 
 ### Detection
 
-Check signals after task-notification.
+**Primary detection: Watchdog health check** (see MUX SKILL.md > WATCHDOG HEALTH CHECK).
+
+After ~10 minutes with no task-notification, call TaskOutput on the background task:
+- Agent still running → do nothing, check again after another ~10 min
+- Agent terminated → relaunch FRESH agent with same prompt (max 2 retries)
+
+**Fallback detection:** Check signals after task-notification.
 
 ```bash
 uv run tools/verify.py "$SESSION_DIR" --action missing --expected 5
@@ -263,7 +269,12 @@ if state["error_context"]:
 
 ### Never Poll for Completion
 
-If task-notification is delayed, use verify.py one-shot check - never poll in a loop.
+If task-notification is delayed, use the **watchdog health check** protocol:
+1. After ~10 min timeout: call TaskOutput as liveness probe
+2. Agent alive → wait for next notification
+3. Agent dead → relaunch FRESH agent (max 2 retries)
+
+For signal verification after task-notification, use verify.py one-shot check - never poll in a loop.
 
 ```python
 # WRONG - polling loop

--- a/plugins/ac-workflow/skills/mux-roadmap/SKILL.md
+++ b/plugins/ac-workflow/skills/mux-roadmap/SKILL.md
@@ -374,6 +374,21 @@ Orchestrator -> Task(Phase Agent) -> Skill(mux-ospec) -> Task(stage workers)
 
 At depth 3, Skill() invocation fails or the phase agent implements directly instead of invoking the skill.
 
+## WATCHDOG HEALTH CHECK
+
+All subagent dispatches from this orchestrator (Strategy Analyst, High-tier Fixer, Sentinel S1/S1.5/S2/S3/S4, CONTINUE.md writer) follow the MUX watchdog protocol.
+
+Full specification: `${CLAUDE_PLUGIN_ROOT}/skills/mux/SKILL.md` > WATCHDOG HEALTH CHECK section.
+
+**Quick reference:**
+- After dispatching any background Task(), wait for task-notification as usual
+- If ~10 min pass with no notification: call TaskOutput as liveness probe
+- Agent alive → do nothing, check again later
+- Agent dead → relaunch FRESH (max 2 retries per task)
+- Max retries exhausted → escalate to user via AskUserQuestion
+
+**Note:** For mux-ospec stages (PLAN, IMPLEMENT, REVIEW, etc.), the watchdog is handled by mux-ospec's own WATCHDOG section. This roadmap-level watchdog applies ONLY to agents dispatched directly by the roadmap orchestrator.
+
 ## MANDATORY VERIFICATION (after mux-ospec stages complete)
 
 Run these checks IN ORDER. If ANY fails, escalate via refinement:

--- a/plugins/ac-workflow/skills/mux/SKILL.md
+++ b/plugins/ac-workflow/skills/mux/SKILL.md
@@ -96,14 +96,14 @@ Everything else = DELEGATE via Task()
 
 ## FORBIDDEN (ZERO TOLERANCE -- HARD-BLOCKED by skill-scoped hooks)
 
-- **TaskOutput()** - NEVER block on agent completion (hook DENY)
+- **TaskOutput()** - FORBIDDEN for blocking on agent completion. **EXCEPTION: Watchdog health checks** (see WATCHDOG HEALTH CHECK section below). When used for watchdog, TaskOutput is a non-blocking liveness probe -- it checks if the agent process is still alive, NOT to read its output.
 - **run_in_background=False** - ALWAYS use True (hook DENY)
 - **Read/Write/Edit/Grep/Glob** - HARD-BLOCKED by skill-scoped hook. Delegate via Task()
 - **WebSearch/WebFetch** - HARD-BLOCKED. Delegate to researcher via Task()
 - **Skill()** - HARD-BLOCKED. Executes IN your context = context suicide
   - **EXCEPTION:** `Skill(skill="mux-ospec")` is allowed ONLY when the orchestrator IS the mux-roadmap orchestrator running phase execution. This is the ONLY sanctioned Skill() call. The orchestrator invokes mux-ospec directly per phase, then delegates stages via Task() as mux-ospec instructs.
 - **Blocking on agents** - Continue immediately after launch; runtime task-notification signals completion
-- **Polling agent output** - NEVER use Read/Bash/tail to check agent progress files. Wait for task-notification, then run verify.py once
+- **Polling agent output** - NEVER use Read/Bash/tail to check agent progress files. Wait for task-notification, then run verify.py once. (Watchdog health checks via TaskOutput are NOT polling -- they are one-shot probes triggered by timeout)
 - **Filesystem polling loops** - NEVER poll .signals/ directory in a loop. Use one-shot check-signals.py or verify.py after notification
 - **Fabricating notifications** - NEVER pretend a task-notification arrived. If no `[notification: task ... completed]` message exists in the conversation, the agent has NOT completed. You are an EVENT LOOP, not a SCRIPT -- you HALT and wait for external input, you do NOT predict or pre-fill what comes next
 
@@ -281,6 +281,76 @@ for item in items:
 
 Signal files are **structured result metadata** (path, size, status, timestamp) that workers write as output. They are NOT the completion detection mechanism. Orchestrator reads them AFTER receiving task-notification, not via polling.
 
+## WATCHDOG HEALTH CHECK (SUBAGENT LIVENESS MONITORING)
+
+### Purpose
+
+Detect silently-dead subagents that terminated without writing a signal file or triggering a task-notification. This prevents the orchestrator from waiting indefinitely for a dead agent.
+
+### Constants
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| WATCHDOG_TIMEOUT | ~10 minutes | Time to wait after launch before first health check |
+| MAX_RELAUNCH_ATTEMPTS | 2 | Maximum times to relaunch a dead subagent per task |
+
+### Protocol
+
+The watchdog is a HEALTH CHECK TRIGGER, never a kill signal. The orchestrator NEVER forcefully kills a running agent.
+
+**After dispatching each subagent via Task(run_in_background=True):**
+
+1. **Continue normally** — end your turn, wait for task-notification as usual
+2. **If ~10 minutes pass with no task-notification AND no signal file:**
+   - Call `TaskOutput` on the background task ID as a **liveness probe**
+   - This is a ONE-SHOT check, not a polling loop
+3. **Interpret TaskOutput result:**
+   - **Agent still running** (TaskOutput returns partial output / no exit code) → Agent is alive. Do NOTHING. Wait for the next task-notification. Check again after another ~10 minutes if still no signal.
+   - **Agent terminated** (TaskOutput shows exit code, empty output, or error) → Agent is DEAD. Proceed to relaunch.
+4. **Relaunch (if agent is dead):**
+   - Increment relaunch counter for this task
+   - If relaunch counter <= MAX_RELAUNCH_ATTEMPTS:
+     - Launch a FRESH agent with the same Task() prompt (NEVER resume a dead agent)
+     - Announce: "Watchdog: Subagent for [task] terminated without signal. Relaunching (attempt {N}/{MAX})."
+   - If relaunch counter > MAX_RELAUNCH_ATTEMPTS:
+     - Mark task as STAGE_FAILED
+     - Escalate to user via AskUserQuestion: "Subagent for [task] has died {MAX} times without completing. Options: retry with different model, skip, or abort."
+
+### Watchdog State Tracking
+
+For each dispatched subagent, track:
+```
+task_id: <background task identifier>
+task_description: <short label, e.g., "phase-1-plan">
+launched_at: <timestamp or turn number>
+relaunch_count: 0
+status: PENDING | COMPLETED | FAILED
+```
+
+This tracking is in-memory (orchestrator's working memory during the session). It does NOT require file persistence.
+
+### Integration with Existing Flow
+
+The watchdog augments, not replaces, the existing completion tracking:
+
+```
+1. Launch subagent (Task, run_in_background=True)
+2. End turn, wait for task-notification          ← EXISTING
+3. [task-notification arrives] → proceed          ← EXISTING
+   OR
+3. [~10 min, no notification] → TaskOutput probe  ← NEW (watchdog)
+   3a. Agent alive → wait more                    ← NEW
+   3b. Agent dead → relaunch                      ← NEW
+```
+
+### Anti-Patterns (NEVER do these)
+
+- **Preemptive health checks** — Do NOT call TaskOutput before ~10 minutes have elapsed. Let the agent work.
+- **Polling loop** — Do NOT call TaskOutput repeatedly in a loop. One check per timeout window.
+- **Killing running agents** — If TaskOutput shows the agent is alive and producing output, do NOTHING. The agent may be slow, not stuck.
+- **Skipping relaunch** — If the agent is dead and retries remain, you MUST relaunch. Do not mark STAGE_FAILED prematurely.
+- **Reusing dead agent context** — Always launch FRESH. Never try to resume or recover a dead agent's partial state.
+
 ## PHASES
 
 1. Decomposition - Parse TASK, extract subjects/output-type
@@ -342,6 +412,7 @@ This cleans up the session marker. Skill-scoped hooks are automatically cleaned 
 | **Report Access** | Only via `extract-summary.py` -- Read is BLOCKED |
 | **Subagent Protocol** | All subagents load mux-subagent skill, return `0` only |
 | **Fail-Closed** | Hook errors -> BLOCK (not allow) |
+| **Watchdog** | TaskOutput allowed ONLY as liveness probe after ~10min timeout. Dead agents relaunched (max 2x). Running agents left alone. |
 
 ## BEHAVIOR DEFAULTS
 

--- a/plugins/ac-workflow/skills/mux/docs/README.md
+++ b/plugins/ac-workflow/skills/mux/docs/README.md
@@ -15,6 +15,7 @@ Parallel research-to-deliverable orchestration via multi-agent multiplexer.
   - [Completion Tracking](#completion-tracking)
   - [Output Format Protocol](#output-format-protocol)
   - [Async Constraints](#async-constraints)
+  - [Watchdog Health Check](#watchdog-health-check)
 - [Session Directory Structure](#session-directory-structure)
 - [Tools Reference](#tools-reference)
 - [Execution Modes](#execution-modes)
@@ -266,6 +267,22 @@ Task(
 **Violations** (blocked by code):
 - `run_in_background=False` or omitted
 - Any synchronous waiting loop
+
+### Watchdog Health Check
+
+**Purpose**: Detect silently-dead subagents that terminated without writing a signal file or triggering a task-notification.
+
+**Protocol** (after dispatching any background Task()):
+
+1. End turn, wait for task-notification as usual
+2. If ~10 minutes pass with no task-notification AND no signal file: call TaskOutput on the background task as a **one-shot liveness probe**
+3. **Agent still running** → do nothing, check again after another ~10 min
+4. **Agent terminated/dead** → relaunch FRESH agent with same prompt (max 2 retries per task)
+5. Max retries exhausted → STAGE_FAILED, escalate to user
+
+**Key constraint**: The watchdog is a health check trigger ONLY — the orchestrator NEVER forcefully kills a running agent.
+
+**Hook change**: `mux-orchestrator-guard.py` now allows `TaskOutput` for watchdog use (previously unconditionally blocked). Instruction-level constraints in SKILL.md limit its use to liveness probes only.
 
 ## Session Directory Structure
 

--- a/plugins/ac-workflow/skills/mux/hooks/mux-orchestrator-guard.py
+++ b/plugins/ac-workflow/skills/mux/hooks/mux-orchestrator-guard.py
@@ -15,7 +15,7 @@ ENFORCEMENT LAYERS:
 2. Write/Edit/NotebookEdit - DENY (delegate via Task)
 3. Grep/Glob - DENY with allowlist (plugin skills/, .claude/hooks/)
 4. WebSearch/WebFetch - DENY (delegate to researcher)
-5. TaskOutput - DENY (use signals)
+5. TaskOutput - ALLOW for watchdog health checks only (instruction-enforced)
 6. Skill - Allowlisted direct call (only mux-ospec), otherwise DENY
 7. Bash - Whitelist (mkdir -p, uv run tools/*)
 8. Task - Validate run_in_background=True
@@ -96,8 +96,10 @@ FORBIDDEN_TOOLS = {
     "NotebookEdit",
     "WebSearch",
     "WebFetch",
-    "TaskOutput",
 }
+
+# Tools allowed ONLY for watchdog health checks (instruction-enforced, not hook-enforced)
+WATCHDOG_TOOLS = {"TaskOutput"}
 
 # Direct Skill() invocations allowed for orchestrator
 ALLOWED_DIRECT_SKILLS = {"mux-ospec"}
@@ -204,7 +206,14 @@ def main() -> None:
                 )))
             return
 
-        # === LAYER 4: Forbidden tools - DENY ===
+        # === LAYER 4a: Watchdog tools - ALLOW (liveness probes only, instruction-enforced) ===
+        if tool_name in WATCHDOG_TOOLS:
+            print(json.dumps(make_decision(
+                "allow",
+            )))
+            return
+
+        # === LAYER 4b: Forbidden tools - DENY ===
         if tool_name in FORBIDDEN_TOOLS:
             print(json.dumps(make_decision(
                 "deny",


### PR DESCRIPTION
## Motivation

During a real `/mux-ospec` session, a PLAN subagent died silently — no signal, no notification, no error. The orchestrator kept waiting indefinitely for a `task-notification` that would never come. The issue was only discovered when the user manually checked and alerted the orchestrator, which then said:

> "Fresh PLAN agent launched. Waiting for task-notification — I'll keep an eye on it this time. If it takes more than ~10 minutes I'll check its output proactively."

This PR codifies that behavior so orchestrators **always** monitor subagent health proactively, instead of relying on the user to notice.

## Summary
- Adds proactive subagent health monitoring to MUX orchestration workflow
- When a subagent dies silently (no signal, no notification), the orchestrator now has instructions to detect and relaunch it instead of waiting indefinitely
- Hook change: `TaskOutput` moved from FORBIDDEN_TOOLS to WATCHDOG_TOOLS so orchestrator can probe agent liveness

## What changed (7 files, 157 insertions, 8 deletions)
- **`mux-orchestrator-guard.py`**: New `WATCHDOG_TOOLS` set, LAYER 4a allows `TaskOutput` for liveness probes
- **`mux/SKILL.md`**: Full WATCHDOG HEALTH CHECK section — constants (`WATCHDOG_TIMEOUT=~10min`, `MAX_RELAUNCH_ATTEMPTS=2`), 4-step protocol, state tracking, anti-patterns
- **`mux-ospec/SKILL.md`**: Watchdog reference in ERROR RECOVERY + quick reference section
- **`mux-roadmap/SKILL.md`**: Watchdog section for roadmap-specific agents
- **`mux-ospec/cookbook/error-recovery.md`**: Updated timeout recovery to reference watchdog protocol
- **`mux/docs/README.md`**: Watchdog subsection in Core Patterns
- **`CHANGELOG.md`**: Unreleased entry documenting the feature

## Key design decisions
- Timeout is a **health check trigger only** — never kills running agents
- If agent is alive & running → do nothing, check again after another ~10min
- If agent is dead/terminated → relaunch fresh agent (max 2 retries)
- Instruction-enforced (not hook-enforced) — the hook allows TaskOutput, the SKILL.md instructions govern when/how to use it

## Test plan
- [x] Hook unit tests: TaskOutput → allow, Write/WebSearch → deny
- [x] Content verification: all 3 SKILL.md files contain WATCHDOG sections
- [x] Python syntax lint on hook file
- [ ] E2E: validated next time a subagent dies in a real mux-ospec session

🤖 Generated with [Claude Code](https://claude.com/claude-code)