### PR TITLE
docs(repo): reframe pi and Claude Code positioning

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Agentic Config Contributors"
   },
   "metadata": {
-    "description": "Agentic workflow automation plugins for AI-assisted development",
+    "description": "Agentic workflow automation via pi packages and Claude Code plugins",
     "pluginRoot": "./plugins"
   },
   "plugins": [

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agentic-config
 
-Project-agnostic, composable configuration system for AI-assisted development workflows.
+Project-agnostic, composable AI workflow automation via pi packages and Claude Code plugins.
 
 ## Quick Start
 
@@ -45,7 +45,7 @@ claude plugin install ac-audit@agentic-plugins
 > Enable them via `/plugins` > Marketplaces > agentic-plugins > Enable auto-update
 > to stay in sync with new releases automatically.
 
-See [Getting Started](docs/getting-started.md) for Claude Code and pi setup.
+See [Getting Started](docs/getting-started.md) for pi and Claude Code setup.
 
 ## Pi Packages
 
@@ -67,7 +67,7 @@ See the [Pi Package Adoption Guide](packages/README.md) for the primary git-tag 
 
 ## What is agentic-config?
 
-A centralized configuration system with Claude Code plugins and a shipped pi package surface.
+A centralized configuration system shipped as pi packages and Claude Code plugins.
 
 Future releases will extend the same plugin approach to additional tools (Cursor, Codex CLI, Gemini CLI, and Antigravity).
 
@@ -75,7 +75,7 @@ Core principles:
 
 1. **Project-agnostic** -- Works in any codebase without modification
 2. **Composable** -- Skills invoke other skills, creating compounding automation
-3. **Native distribution surfaces** -- Claude via `claude plugin install`; pi via `pi install`
+3. **Native distribution surfaces** -- pi via `pi install`; Claude Code via `claude plugin install`
 
 ## Plugins
 
@@ -94,7 +94,7 @@ Core principles:
 - [Getting Started](docs/getting-started.md) -- Install, setup, first use
 - [Plugin Catalog](docs/plugin-catalog.md) -- All 42 skills with composition patterns
 - [pimux Workflow Topologies](docs/pimux-workflow-topologies.md) -- `pimux`, mux, ospec, and roadmap hierarchy guide
-- [Distribution Guide](docs/distribution.md) -- Claude marketplace rollout plus pi git-tag distribution, dev branch installs, and future npm notes
+- [Distribution Guide](docs/distribution.md) -- pi git-tag installs, Claude marketplace rollout, dev branch installs, and future npm notes
 - [Pi Package Adoption Guide](packages/README.md) -- primary git-tag installs, branch-based dev installs, local package-root testing, and future npm distribution notes
 - [Migration Guide v0.2.0](docs/migration-v0.2.0.md) -- Migrate from v0.1.x
 - [Uninstall Legacy (v0.1.x)](docs/migration-v0.2.0.md#step-1-remove-old-symlinks) -- Remove legacy symlink wiring

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -1,8 +1,8 @@
 # Distribution Guide
 
-Team and enterprise distribution of agentic-config for Claude Code plugins and pi packages.
+Team and enterprise distribution of agentic-config across pi packages and Claude Code plugins.
 
-Claude Code uses the marketplace flow below. Pi currently uses validated git-tag installs of the root umbrella package as the primary distribution path, with branch refs for development and local package-root installs for validation. Per-package npm distribution remains future work.
+Pi currently uses validated git-tag installs of the root umbrella package as the primary distribution path, with branch refs for development and local package-root installs for validation. Claude Code uses the marketplace flow below. Per-package npm distribution remains future work.
 
 ## Claude Code Marketplace Distribution
 
@@ -239,6 +239,6 @@ All customizations are isolated to the private fork.
 
 ## See Also
 
-- [Getting Started](getting-started.md) -- Claude Code and pi setup
+- [Getting Started](getting-started.md) -- pi and Claude Code setup
 - [Pi Package Adoption Guide](../packages/README.md) -- npm installs, alternative git installs, committed `.pi/settings.json`, and local pre-distribution testing
 - [Migration Guide v0.2.0](migration-v0.2.0.md) -- Migrate from v0.1.x symlinks

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,28 +1,12 @@
 # Getting Started
 
-Setup and first use of agentic-config for AI-assisted development workflows.
+Setup and first use of agentic-config across pi packages and Claude Code plugins.
 
 ## Prerequisites
 
-- Claude Code CLI with plugin support (`claude plugin install` available) for Claude Code setup
 - Pi CLI (`pi install` available) for pi package setup
-- Git (for Claude marketplace access)
-
-## Install for Claude Code
-
-Add the marketplace, then install plugins:
-
-```bash
-claude plugin marketplace add WaterplanAI/agentic-config
-
-claude plugin install ac-workflow@agentic-plugins
-claude plugin install ac-git@agentic-plugins
-claude plugin install ac-qa@agentic-plugins
-claude plugin install ac-tools@agentic-plugins
-claude plugin install ac-meta@agentic-plugins
-claude plugin install ac-safety@agentic-plugins
-claude plugin install ac-audit@agentic-plugins
-```
+- Claude Code CLI with plugin support (`claude plugin install` available) for Claude Code setup
+- Git (for Claude marketplace access and git-based pi installs)
 
 ## Install for pi
 
@@ -69,6 +53,22 @@ pi install ./packages/pi-ac-workflow -l
 For bundled package roots such as `pi-all`, use the staged local testing flow from the [Pi Package Adoption Guide](../packages/README.md#local-package-testing-before-distribution).
 
 Publishing the per-package npm surface remains future work. See the [Pi Package Adoption Guide](../packages/README.md) for the full install matrix.
+
+## Install for Claude Code
+
+Add the marketplace, then install plugins:
+
+```bash
+claude plugin marketplace add WaterplanAI/agentic-config
+
+claude plugin install ac-workflow@agentic-plugins
+claude plugin install ac-git@agentic-plugins
+claude plugin install ac-qa@agentic-plugins
+claude plugin install ac-tools@agentic-plugins
+claude plugin install ac-meta@agentic-plugins
+claude plugin install ac-safety@agentic-plugins
+claude plugin install ac-audit@agentic-plugins
+```
 
 ## Enable Auto-Updates (Recommended)
 
@@ -199,13 +199,13 @@ Add project-specific customizations directly to AGENTS.md.
 
 ## What Gets Installed
 
-**Claude Code plugins (via `claude plugin install`):**
-- `ac-workflow`, `ac-git`, `ac-qa`, `ac-tools`, `ac-meta`, `ac-safety`, `ac-audit`
-- No symlinks -- plugins load from `~/.claude/plugins/cache/`
-
 **Pi packages (via `pi install`):**
 - `@agentic-config/pi-all` for the full shipped surface, or selective `@agentic-config/pi-*` packages
 - Team rollout is typically versioned in committed `.pi/settings.json`
+
+**Claude Code plugins (via `claude plugin install`):**
+- `ac-workflow`, `ac-git`, `ac-qa`, `ac-tools`, `ac-meta`, `ac-safety`, `ac-audit`
+- No symlinks -- plugins load from `~/.claude/plugins/cache/`
 
 **Copied (project-customizable):**
 - `AGENTS.md` -- Project-specific guidelines
@@ -266,7 +266,7 @@ Pi:
 
 - [Plugin Catalog](plugin-catalog.md) -- All skills by plugin
 - [pimux Workflow Topologies](pimux-workflow-topologies.md) -- `pimux`, mux, ospec, and roadmap runtime guide
-- [Distribution Guide](distribution.md) -- Claude marketplace rollout plus pi git-tag distribution, dev branch installs, and future npm notes
+- [Distribution Guide](distribution.md) -- pi git-tag installs, Claude marketplace rollout, dev branch installs, and future npm notes
 - [Pi Package Adoption Guide](../packages/README.md) -- primary git-tag installs, branch-based dev installs, local package-root testing, and future npm distribution notes
 - [Migration Guide v0.2.0](migration-v0.2.0.md) -- Migrate from v0.1.x symlinks
 - [External Specs Storage](external-specs-storage.md) -- Configure external specs repository

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ Table of contents for agentic-config documentation.
 | [Getting Started](getting-started.md) | Installation, setup, first use, troubleshooting |
 | [Plugin Catalog](plugin-catalog.md) | All 42 skills across 7 plugins with composition patterns |
 | [pimux Workflow Topologies](pimux-workflow-topologies.md) | How `pimux`, mux, ospec, and roadmap nest and communicate |
-| [Distribution Guide](distribution.md) | Claude marketplace rollout plus pi git-tag team adoption, dev branch installs, and future npm notes |
+| [Distribution Guide](distribution.md) | pi git-tag installs, Claude marketplace rollout, dev branch installs, and future npm notes |
 | [Pi Package Adoption Guide](../packages/README.md) | primary git-tag installs, branch-based dev installs, local package-root testing, and future npm distribution notes |
 | [Migration Guide v0.2.0](migration-v0.2.0.md) | Migrate from v0.1.x symlinks to CC-native plugins |
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agentic-config-pi-root",
   "private": true,
   "version": "0.3.0-alpha",
-  "description": "Git-installable umbrella pi package for agentic-config.",
+  "description": "Umbrella pi package for agentic-config, alongside the repository's Claude Code plugin surface.",
   "license": "MIT",
   "homepage": "https://github.com/WaterplanAI/agentic-config",
   "repository": {


### PR DESCRIPTION
## Summary

This PR rewrites the top-level repository framing so pi package distribution leads naturally, while Claude Code remains the secondary supported surface. It keeps the message the same across the repo entry points, setup docs, and marketplace/package metadata.

- Reword repo-level summaries to say "pi packages and Claude Code plugins"
- Keep pi install/setup guidance ahead of Claude Code where users first land
- Align package and marketplace metadata with the same top-level framing

### Root Cause (if applicable)
Repo-facing descriptions still tended to describe Claude Code first even though the current shipped distribution story and docs now lead with pi.

### Key Changes

**Top-level positioning:**
- Updates `README.md`, `package.json`, and `.claude-plugin/marketplace.json` to describe the project in pi-plus-Claude-Code terms without awkward "pi first" wording

**Setup and distribution docs:**
- Reorders and rewrites the top of `docs/getting-started.md` so pi install/setup appears before Claude Code
- Rewords `docs/distribution.md` and `docs/index.md` so pi rollout is described before Claude marketplace rollout

## Test Plan

- [x] Run `uv run pytest -q`
- [x] Run `uv run ruff check .`
- [x] Run `git diff --check HEAD`

## Files Changed

**Repo metadata:**
- `.claude-plugin/marketplace.json` - reword marketplace metadata description
- `package.json` - update root package description

**Primary docs:**
- `README.md` - lead with pi packages in repo-facing framing
- `docs/getting-started.md` - reorder and reword setup/install entry points
- `docs/distribution.md` - reword distribution overview and references
- `docs/index.md` - update distribution guide summary text

## Related

- **Spec**: `.specs/specs/2026/04/docs-pi-claude-framing/000-backlog.md`

Generated with pi