### PR TITLE
feat(hook-compat): add scoped safety hook approvals

### DIFF
--- a/packages/pi-ac-safety/assets/config/safety.default.yaml
+++ b/packages/pi-ac-safety/assets/config/safety.default.yaml
@@ -155,6 +155,8 @@ playwright:
     - "www.google.com"
     - "serper.dev"
     - "serpapi.com"
+  allowed_cli_actions: []
+  allowed_mcp_actions: []
   always_blocked_tools:
     - "browser_evaluate"
     - "browser_fill_form"

--- a/packages/pi-ac-safety/assets/scripts/hooks/_lib.py
+++ b/packages/pi-ac-safety/assets/scripts/hooks/_lib.py
@@ -37,6 +37,10 @@ def _most_restrictive(a: str, b: str) -> str:
 # (overlay adds to base, never replaces). Matched by suffix.
 _UNION_MERGE_SUFFIXES = ("_prefixes", "_allowlist", "_files", "_filenames", "_extensions", "_tools", "_roots")
 
+# Specific list keys that also require union-merge semantics even though they do
+# not use one of the generic suffixes above.
+_UNION_MERGE_KEYS = frozenset({"allowed_domains", "allowed_cli_actions", "allowed_mcp_actions"})
+
 
 def _deep_merge(base: dict, overlay: dict) -> dict:
     """
@@ -44,7 +48,8 @@ def _deep_merge(base: dict, overlay: dict) -> dict:
 
     For category decision dicts, applies most-restrictive-wins.
     For security-critical lists (keys ending in _prefixes, _allowlist,
-    _files, _filenames, _extensions), merges by union (combine + deduplicate).
+    _files, _filenames, _extensions) plus selected explicit allow-list keys,
+    merges by union (combine + deduplicate).
     For other lists, overlay replaces base entirely.
     For dicts, recursively merge.
     """
@@ -70,7 +75,7 @@ def _deep_merge(base: dict, overlay: dict) -> dict:
                 result[key] = _deep_merge(result[key], overlay_val)
         elif isinstance(result[key], list) and isinstance(overlay_val, list):
             # Security-critical lists: union-merge to prevent accidental loss of defaults
-            if any(key.endswith(suffix) for suffix in _UNION_MERGE_SUFFIXES):
+            if key in _UNION_MERGE_KEYS or any(key.endswith(suffix) for suffix in _UNION_MERGE_SUFFIXES):
                 seen: set[str] = set()
                 merged_list: list[Any] = []
                 for item in result[key] + overlay_val:
@@ -289,14 +294,47 @@ def allow() -> None:
     }))
 
 
-def ask(reason: str) -> None:
-    """Print JSON ask decision to stdout."""
-    print(json.dumps({
-        "hookSpecificOutput": {
-            "hookEventName": "PreToolUse",
-            "permissionDecision": "ask",
-            "permissionDecisionReason": reason,
+def build_permission_decision_metadata(
+    allow_key: str | None = None,
+    project_patch: dict[str, Any] | None = None,
+    user_patch: dict[str, Any] | None = None,
+    script_path: str = "scripts/hooks/persist-allow.py",
+) -> dict[str, Any]:
+    """Build optional metadata consumed by hook-compat's richer ask UI."""
+    metadata: dict[str, Any] = {}
+    if allow_key:
+        metadata["allowKey"] = allow_key
+    if project_patch:
+        metadata["projectPersistence"] = {
+            "scriptPath": script_path,
+            "payload": {
+                "target": "project",
+                "patch": project_patch,
+            },
         }
+    if user_patch:
+        metadata["userPersistence"] = {
+            "scriptPath": script_path,
+            "payload": {
+                "target": "user",
+                "patch": user_patch,
+            },
+        }
+    return metadata
+
+
+
+def ask(reason: str, metadata: dict[str, Any] | None = None) -> None:
+    """Print JSON ask decision to stdout."""
+    hook_output: dict[str, Any] = {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "ask",
+        "permissionDecisionReason": reason,
+    }
+    if metadata:
+        hook_output["permissionDecisionMetadata"] = metadata
+    print(json.dumps({
+        "hookSpecificOutput": hook_output
     }))
 
 

--- a/packages/pi-ac-safety/assets/scripts/hooks/persist-allow.py
+++ b/packages/pi-ac-safety/assets/scripts/hooks/persist-allow.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pyyaml"]
+# ///
+"""Persist narrow safety allow overrides to project or user safety.yaml."""
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _lib import _deep_merge, _strip_broad_entries  # noqa: E402
+
+
+MAX_CONFIG_SIZE = 1_048_576
+
+
+def _safe_read_yaml(path: Path) -> dict[str, Any]:
+    try:
+        content = path.read_bytes()
+    except FileNotFoundError:
+        return {}
+    except IsADirectoryError as exc:
+        raise ValueError(f"Config target is a directory: {path}") from exc
+    except PermissionError as exc:
+        raise ValueError(f"Config target is not readable: {path}") from exc
+
+    if len(content) > MAX_CONFIG_SIZE:
+        raise ValueError(f"Config file exceeds {MAX_CONFIG_SIZE} bytes: {path}")
+
+    loaded = yaml.safe_load(content)
+    if loaded is None:
+        return {}
+    if not isinstance(loaded, dict):
+        raise ValueError(f"Config file must contain a YAML mapping: {path}")
+    return loaded
+
+
+def _resolve_target_path(target: str) -> Path:
+    normalized = target.strip().lower()
+    if normalized == "project":
+        project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+        return project_dir / "safety.yaml"
+    if normalized == "user":
+        return Path.home() / ".claude" / "safety.yaml"
+    raise ValueError(f"Unsupported persistence target: {target}")
+
+
+def main() -> None:
+    payload = json.load(sys.stdin)
+    if not isinstance(payload, dict):
+        raise ValueError("Persistence payload must be a JSON object.")
+
+    target = payload.get("target")
+    patch = payload.get("patch")
+    if not isinstance(target, str) or not target.strip():
+        raise ValueError("Persistence payload requires a non-empty 'target'.")
+    if not isinstance(patch, dict) or not patch:
+        raise ValueError("Persistence payload requires a non-empty object 'patch'.")
+
+    target_path = _resolve_target_path(target)
+    existing = _safe_read_yaml(target_path)
+    merged = _deep_merge(existing, patch)
+    merged = _strip_broad_entries(merged)
+
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    rendered = yaml.safe_dump(merged, sort_keys=False, allow_unicode=False)
+    target_path.write_text(rendered, encoding="utf-8")
+
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "targetPath": str(target_path),
+                "message": f"Saved safety allow override in {target_path}.",
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/pi-ac-safety/assets/scripts/hooks/playwright-guardian.py
+++ b/packages/pi-ac-safety/assets/scripts/hooks/playwright-guardian.py
@@ -24,7 +24,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from _lib import allow, ask, deny, fail_close, get_category_decision, load_config
+from _lib import allow, ask, build_permission_decision_metadata, deny, fail_close, get_category_decision, load_config
 
 MCP_PREFIXES = ["mcp__playwright__", "mcp__plugin_playwright_playwright__"]
 _PLAYWRIGHT_CLI_NAME = "playwright-cli"
@@ -105,6 +105,7 @@ class PlaywrightInvocation:
     url: str = ""
 
 
+
 def _get_mcp_action(tool_name: str) -> str | None:
     """Return the Playwright MCP action name for a tool name."""
     for prefix in MCP_PREFIXES:
@@ -113,20 +114,31 @@ def _get_mcp_action(tool_name: str) -> str | None:
     return None
 
 
-def _is_domain_allowed(url: str, allowed_domains: set[str]) -> bool:
-    """Return True when the URL hostname matches the allowlist."""
+
+def _normalize_hostname(url: str) -> str:
+    """Return a normalized hostname used for domain allowlisting."""
     try:
         parsed = urlparse(url)
         hostname = parsed.hostname or ""
-        bare_host = hostname.removeprefix("www.")
-        return hostname in allowed_domains or bare_host in allowed_domains or f"www.{bare_host}" in allowed_domains
     except Exception:
+        return ""
+    return hostname.removeprefix("www.")
+
+
+
+def _is_domain_allowed(url: str, allowed_domains: set[str]) -> bool:
+    """Return True when the URL hostname matches the allowlist."""
+    bare_host = _normalize_hostname(url)
+    if not bare_host:
         return False
+    return bare_host in allowed_domains or f"www.{bare_host}" in allowed_domains
+
 
 
 def _is_env_assignment(token: str) -> bool:
     """Return True when a token is a shell environment assignment."""
     return re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", token) is not None
+
 
 
 def _split_shell_segments(command: str) -> list[list[str]]:
@@ -155,6 +167,7 @@ def _split_shell_segments(command: str) -> list[list[str]]:
     return segments
 
 
+
 def _trim_cli_wrappers(args: list[str]) -> list[str]:
     """Remove shell wrappers and leading env assignments before command lookup."""
     idx = 0
@@ -168,6 +181,7 @@ def _trim_cli_wrappers(args: list[str]) -> list[str]:
             continue
         break
     return args[idx:]
+
 
 
 def _extract_cli_action(args: list[str]) -> tuple[str | None, list[str]]:
@@ -191,6 +205,7 @@ def _extract_cli_action(args: list[str]) -> tuple[str | None, list[str]]:
     return None, []
 
 
+
 def _extract_cli_url(action: str, action_args: list[str]) -> str:
     """Return the URL carried by a navigation-style playwright-cli action."""
     if action not in _URL_ACTIONS:
@@ -199,6 +214,7 @@ def _extract_cli_url(action: str, action_args: list[str]) -> str:
         if not arg.startswith("-"):
             return arg
     return ""
+
 
 
 def _resolve_cli_invocation(segment_args: list[str]) -> PlaywrightInvocation | None:
@@ -222,6 +238,7 @@ def _resolve_cli_invocation(segment_args: list[str]) -> PlaywrightInvocation | N
         source="bash",
         url=_extract_cli_url(raw_action, action_args),
     )
+
 
 
 def _resolve_playwright_invocations(tool_name: str, tool_input: dict[str, Any]) -> list[PlaywrightInvocation]:
@@ -249,11 +266,13 @@ def _resolve_playwright_invocations(tool_name: str, tool_input: dict[str, Any]) 
     return invocations
 
 
+
 def _format_action_label(invocation: PlaywrightInvocation) -> str:
     """Return a human-readable action label for policy messages."""
     if invocation.source == "bash":
         return f"playwright-cli {invocation.raw_action}"
     return invocation.raw_action
+
 
 
 def _decide_from_category(
@@ -271,7 +290,57 @@ def _decide_from_category(
     return "allow", ""
 
 
-def _evaluate_invocation(invocation: PlaywrightInvocation, config: dict[str, Any]) -> tuple[str, str]:
+
+def _build_action_allow_metadata(invocation: PlaywrightInvocation) -> dict[str, Any] | None:
+    """Return persistence metadata for an exact Playwright action override."""
+    raw_action = invocation.raw_action.strip()
+    if not raw_action:
+        return None
+
+    patch_key = "allowed_cli_actions" if invocation.source == "bash" else "allowed_mcp_actions"
+    patch = {
+        "playwright": {
+            patch_key: [raw_action],
+        }
+    }
+    return build_permission_decision_metadata(
+        allow_key=f"playwright:{invocation.source}:action:{raw_action}",
+        project_patch=patch,
+        user_patch=patch,
+    )
+
+
+
+def _build_domain_allow_metadata(invocation: PlaywrightInvocation) -> dict[str, Any] | None:
+    """Return persistence metadata for an exact blocked-domain override."""
+    bare_host = _normalize_hostname(invocation.url)
+    if not bare_host:
+        return None
+
+    patch = {
+        "playwright": {
+            "allowed_domains": [bare_host],
+        }
+    }
+    return build_permission_decision_metadata(
+        allow_key=f"playwright:domain:{bare_host}",
+        project_patch=patch,
+        user_patch=patch,
+    )
+
+
+
+def _build_invocation_allow_metadata(invocation: PlaywrightInvocation, category: str) -> dict[str, Any] | None:
+    """Return richer ask metadata for narrowly persistable Playwright prompts."""
+    if category == "navigate-blocked-domain":
+        return _build_domain_allow_metadata(invocation)
+    if category in {"browser-file-upload", "unknown-mcp-action"}:
+        return _build_action_allow_metadata(invocation)
+    return None
+
+
+
+def _evaluate_invocation(invocation: PlaywrightInvocation, config: dict[str, Any]) -> tuple[str, str, dict[str, Any] | None]:
     """Return the policy decision for a normalized Playwright invocation."""
     action_label = _format_action_label(invocation)
     pw = config.get("playwright", {})
@@ -281,39 +350,51 @@ def _evaluate_invocation(invocation: PlaywrightInvocation, config: dict[str, Any
     always_blocked = set(pw.get("always_blocked_tools", list(DEFAULT_ALWAYS_BLOCKED)))
     always_allowed = set(pw.get("always_allowed_tools", list(DEFAULT_ALWAYS_ALLOWED)))
     allowed_domains = set(pw.get("allowed_domains", list(DEFAULT_ALLOWED_DOMAINS)))
+    allowed_cli_actions = set(str(item) for item in pw.get("allowed_cli_actions", []))
+    allowed_mcp_actions = set(str(item) for item in pw.get("allowed_mcp_actions", []))
 
     if invocation.action in always_blocked:
-        return "deny", f"BLOCKED: {action_label} is always blocked (arbitrary code execution / credential risk)"
+        return "deny", f"BLOCKED: {action_label} is always blocked (arbitrary code execution / credential risk)", None
 
     if invocation.action in always_allowed:
-        return "allow", ""
+        return "allow", "", None
 
     if invocation.url and not _is_domain_allowed(invocation.url, allowed_domains):
-        return _decide_from_category(
+        decision, message = _decide_from_category(
             config,
             "navigate-blocked-domain",
             f"BLOCKED: {action_label} targeting '{invocation.url}' denied (domain not in allowlist)",
             f"{action_label} targeting '{invocation.url}' is outside the allowed domain list. Allow?",
         )
+        metadata = _build_invocation_allow_metadata(invocation, "navigate-blocked-domain") if decision == "ask" else None
+        return decision, message, metadata
+
+    raw_allowlist = allowed_cli_actions if invocation.source == "bash" else allowed_mcp_actions
+    if invocation.raw_action in raw_allowlist:
+        return "allow", "", None
 
     if invocation.action == "browser_navigate":
-        return "allow", ""
+        return "allow", "", None
 
     category = CATEGORY_BY_ACTION.get(invocation.action)
     if category is not None:
-        return _decide_from_category(
+        decision, message = _decide_from_category(
             config,
             category,
             f"BLOCKED: {action_label} denied by Playwright policy",
             f"{action_label} detected -- confirm to proceed?",
         )
+        metadata = _build_invocation_allow_metadata(invocation, category) if decision == "ask" else None
+        return decision, message, metadata
 
-    return _decide_from_category(
+    decision, message = _decide_from_category(
         config,
         "unknown-mcp-action",
         f"BLOCKED: Unknown Playwright action '{action_label}' denied by default",
         f"Unknown Playwright action '{action_label}' -- confirm to proceed?",
     )
+    metadata = _build_invocation_allow_metadata(invocation, "unknown-mcp-action") if decision == "ask" else None
+    return decision, message, metadata
 
 
 @fail_close
@@ -332,13 +413,13 @@ def main() -> None:
 
     config = load_config()
     for invocation in invocations:
-        decision, message = _evaluate_invocation(invocation, config)
+        decision, message, metadata = _evaluate_invocation(invocation, config)
         if decision == "allow":
             continue
         if decision == "deny":
             deny(message)
             return
-        ask(message)
+        ask(message, metadata=metadata)
         return
 
     allow()

--- a/packages/pi-ac-safety/assets/scripts/hooks/supply-chain-guardian.py
+++ b/packages/pi-ac-safety/assets/scripts/hooks/supply-chain-guardian.py
@@ -15,9 +15,10 @@ import os
 import re
 import shlex
 import sys
+from typing import Any
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from _lib import allow, ask, deny, fail_close, get_category_decision, load_config
+from _lib import allow, ask, build_permission_decision_metadata, deny, fail_close, get_category_decision, load_config
 
 # Patterns that are SAFE (skip blocking).
 # These are applied per-segment (after splitting on shell operators).
@@ -55,13 +56,13 @@ SAFE_PATTERNS = [
 ]
 
 
-def _apply_decision(config: dict, category: str, reason: str) -> None:
+def _apply_decision(config: dict, category: str, reason: str, metadata: dict | None = None) -> None:
     """Apply the configured decision for a supply_chain category."""
     decision = get_category_decision(config, "supply_chain", category)
     if decision == "deny":
         deny(f"BLOCKED: {reason}. Supply-chain-guardian.")
     elif decision == "ask":
-        ask(f"{reason} -- confirm to proceed?")
+        ask(f"{reason} -- confirm to proceed?", metadata=metadata)
     else:
         allow()
 
@@ -294,6 +295,129 @@ def _extract_all_package_args(args: list[str]) -> list[str]:
     return [arg for arg in args if not arg.startswith("-")]
 
 
+
+def _dedupe_packages(packages: list[str]) -> list[str]:
+    """Normalize package names for persistence allowlists."""
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for package in packages:
+        stripped = _strip_version(package)
+        if not stripped or stripped in seen:
+            continue
+        seen.add(stripped)
+        normalized.append(stripped)
+    return normalized
+
+
+
+def _extract_npx_packages(segment: str) -> list[str]:
+    """Return exact transient packages that can be allowlisted."""
+    extractors: list[tuple[str, set[str]]] = [
+        (r"\bnpx\s+(.*)", {"--package", "-p"}),
+        (r"\bnpm\s+exec\s+(.*)", {"--package"}),
+        (r"\bpnpm\s+dlx\s+(.*)", set()),
+        (r"\byarn\s+dlx\s+(.*)", set()),
+        (r"\bbunx\s+(.*)", {"--package", "-p"}),
+        (r"\buvx\s+(.*)", {"--with", "--from"}),
+        (r"\buv\s+tool\s+run\s+(.*)", {"--from"}),
+    ]
+    for pattern, package_flags in extractors:
+        match = re.search(pattern, segment)
+        if not match:
+            continue
+        package = _extract_package_from_runner_args(_split_args(match.group(1)), package_flags)
+        return _dedupe_packages([package] if package else [])
+    return []
+
+
+
+def _extract_uv_add_packages(command: str) -> list[str]:
+    """Extract package args from `uv add` for persistence allowlists."""
+    match = re.search(r"\buv\s+add\s+(.*)", command)
+    if not match:
+        return []
+
+    bare_flags = {"--dev", "--no-sync", "--frozen", "--locked", "--editable"}
+    value_flags = {"--group", "--optional", "--extra", "--tag", "--branch", "--rev"}
+    args = _split_args(match.group(1))
+    packages: list[str] = []
+    idx = 0
+    while idx < len(args):
+        arg = args[idx]
+        if arg == "--":
+            idx += 1
+            while idx < len(args):
+                if not args[idx].startswith("-"):
+                    packages.append(args[idx])
+                idx += 1
+            break
+        if arg in bare_flags:
+            idx += 1
+            continue
+        if arg in value_flags:
+            idx += 2
+            continue
+        if any(arg.startswith(f"{flag}=") for flag in value_flags):
+            idx += 1
+            continue
+        if arg.startswith("-"):
+            idx += 1
+            continue
+        packages.append(arg)
+        idx += 1
+    return _dedupe_packages(packages)
+
+
+
+def _extract_install_packages(command: str, pattern: str) -> list[str]:
+    """Extract package args for add/install-style commands."""
+    match = re.search(pattern, command)
+    if not match:
+        return []
+    return _dedupe_packages(_extract_all_package_args(_split_args(match.group(1))))
+
+
+
+def _build_persistence_metadata(segment: str, category: str) -> dict[str, Any] | None:
+    """Return narrow allowlist persistence metadata for selected categories."""
+    allowlist_key_by_category = {
+        "npx-packages": "npx_allowlist",
+        "uv-add": "uv_add_allowlist",
+        "npm-install": "npm_install_allowlist",
+        "yarn-add": "yarn_add_allowlist",
+    }
+    allowlist_key = allowlist_key_by_category.get(category)
+    if allowlist_key is None:
+        return None
+
+    if category == "npx-packages":
+        packages = _extract_npx_packages(segment)
+    elif category == "uv-add":
+        packages = _extract_uv_add_packages(segment)
+    elif category == "npm-install":
+        packages = (
+            _extract_install_packages(segment, r"\bnpm\s+(?:install|i)\s+(.*)")
+            or _extract_install_packages(segment, r"\bpnpm\s+add\s+(.*)")
+            or _extract_install_packages(segment, r"\bbun\s+add\s+(.*)")
+        )
+    else:
+        packages = _extract_install_packages(segment, r"\byarn\s+add\s+(.*)")
+
+    if not packages:
+        return None
+
+    patch = {
+        "supply_chain": {
+            allowlist_key: packages,
+        }
+    }
+    return build_permission_decision_metadata(
+        allow_key=f"supply-chain:{category}:{','.join(packages)}",
+        project_patch=patch,
+        user_patch=patch,
+    )
+
+
 def _is_npm_install_blocked(command: str, npm_install_allowlist: set[str]) -> str | None:
     """Check for npm install/i <package> (not bare npm install / npm ci).
 
@@ -453,7 +577,7 @@ def main() -> None:
             npm_install_allowlist, yarn_add_allowlist,
         )
         if reason:
-            _apply_decision(config, category, reason)
+            _apply_decision(config, category, reason, metadata=_build_persistence_metadata(segment, category))
             return
 
     allow()

--- a/packages/pi-compat/extensions/hook-compat/README.md
+++ b/packages/pi-compat/extensions/hook-compat/README.md
@@ -83,7 +83,9 @@ export default function registerGitCompat(pi) {
 - For each matched hook:
   - `allow`: continue
   - `deny`: block immediately
-  - `ask`: use UI confirmation when available; otherwise apply `askFallback.nonInteractive`
+  - `ask`: use UI selection when available; otherwise apply `askFallback.nonInteractive`
+    - default interactive options: `Allow once`, `Allow for rest of this session`, `Deny`
+    - hooks may optionally provide project/user persistence metadata to add `Always allow in this project` and `Always allow from now on`
   - no `permissionDecision`: continue (side-effects and optional `systemMessage` are valid)
 - `user_bash` deny paths return a synthetic blocked bash result so pi does not execute the command.
 - Script execution uses:
@@ -93,7 +95,8 @@ export default function registerGitCompat(pi) {
 - Adapter-layer failures follow each hook's `failureMode` (`fail-open` or `fail-close`).
 
 ## Non-interactive `ask` behavior
-- If `ctx.hasUI` is true and `ctx.ui.confirm(...)` exists, `ask` opens a confirmation dialog.
+- If `ctx.hasUI` is true and `ctx.ui.select(...)` exists, `ask` opens a selection dialog.
+- If select is unavailable but `ctx.ui.confirm(...)` exists, hook-compat falls back to a yes/no confirmation dialog.
 - Otherwise hook-compat treats `ask` as non-interactive and applies the package registration fallback:
   - `askFallback.nonInteractive: "deny"` blocks by default
   - `askFallback.nonInteractive: "allow"` continues without prompting

--- a/packages/pi-compat/extensions/hook-compat/allow-state.js
+++ b/packages/pi-compat/extensions/hook-compat/allow-state.js
@@ -1,0 +1,117 @@
+import { resolveClaudeSessionId } from "./env.js";
+
+const ALLOW_ENTRY_TYPE = "hook-compat-allow";
+const STATE_SYMBOL = Symbol.for("@agentic-config/pi-compat/hook-compat-allow-state");
+const FALLBACK_RUNTIME_KEY = Object.freeze({ name: "hook-compat-global-fallback" });
+
+function createEmptyState() {
+  return {
+    storesByRuntime: new WeakMap(),
+  };
+}
+
+function getGlobalState() {
+  const scope = globalThis;
+  if (!scope[STATE_SYMBOL]) {
+    scope[STATE_SYMBOL] = createEmptyState();
+  }
+  return scope[STATE_SYMBOL];
+}
+
+function resolveRuntimeKey(runtime) {
+  if ((!runtime || typeof runtime !== "object") && typeof runtime !== "function") {
+    return FALLBACK_RUNTIME_KEY;
+  }
+
+  const sharedEvents = runtime.events;
+  if ((typeof sharedEvents === "object" && sharedEvents !== null) || typeof sharedEvents === "function") {
+    return sharedEvents;
+  }
+
+  return runtime;
+}
+
+function getRuntimeStore(runtime) {
+  const runtimeKey = resolveRuntimeKey(runtime);
+  const state = getGlobalState();
+  const existing = state.storesByRuntime.get(runtimeKey);
+  if (existing) {
+    return existing;
+  }
+
+  const store = new Map();
+  state.storesByRuntime.set(runtimeKey, store);
+  return store;
+}
+
+function getSessionCacheKey(ctx) {
+  const sessionId = resolveClaudeSessionId(ctx);
+  const cwd = typeof ctx?.cwd === "string" && ctx.cwd.trim() !== "" ? ctx.cwd : process.cwd();
+  return `${cwd}::${sessionId}`;
+}
+
+function loadPersistedAllowKeys(ctx) {
+  const branch = typeof ctx?.sessionManager?.getBranch === "function" ? ctx.sessionManager.getBranch() : [];
+  const allowKeys = new Set();
+
+  for (const entry of branch) {
+    if (!entry || entry.type !== "custom" || entry.customType !== ALLOW_ENTRY_TYPE) {
+      continue;
+    }
+
+    const allowKey = entry.data?.allowKey;
+    if (typeof allowKey === "string" && allowKey.trim() !== "") {
+      allowKeys.add(allowKey);
+    }
+  }
+
+  return allowKeys;
+}
+
+function getSessionAllowSet(runtime, ctx) {
+  const runtimeStore = getRuntimeStore(runtime);
+  const sessionCacheKey = getSessionCacheKey(ctx);
+  const existing = runtimeStore.get(sessionCacheKey);
+  if (existing) {
+    return existing;
+  }
+
+  const loaded = loadPersistedAllowKeys(ctx);
+  runtimeStore.set(sessionCacheKey, loaded);
+  return loaded;
+}
+
+export function hasSessionAllow(runtime, ctx, allowKey) {
+  if (typeof allowKey !== "string" || allowKey.trim() === "") {
+    return false;
+  }
+
+  return getSessionAllowSet(runtime, ctx).has(allowKey);
+}
+
+export function grantSessionAllow(runtime, ctx, allowKey) {
+  if (typeof allowKey !== "string" || allowKey.trim() === "") {
+    return;
+  }
+
+  const allowSet = getSessionAllowSet(runtime, ctx);
+  if (allowSet.has(allowKey)) {
+    return;
+  }
+
+  allowSet.add(allowKey);
+
+  if (runtime && typeof runtime.appendEntry === "function") {
+    runtime.appendEntry(ALLOW_ENTRY_TYPE, { allowKey });
+  }
+}
+
+export function clearHookCompatAllowState(runtime) {
+  const runtimeKey = resolveRuntimeKey(runtime);
+  const state = getGlobalState();
+  state.storesByRuntime.delete(runtimeKey);
+}
+
+export function resetHookCompatAllowStateForTests() {
+  globalThis[STATE_SYMBOL] = createEmptyState();
+}

--- a/packages/pi-compat/extensions/hook-compat/decision.js
+++ b/packages/pi-compat/extensions/hook-compat/decision.js
@@ -1,3 +1,9 @@
+import { createHash } from "node:crypto";
+
+import { clearHookCompatAllowState, grantSessionAllow, hasSessionAllow } from "./allow-state.js";
+import { buildClaudeCompatEnv, normalizeSpawnCwd, resolveClaudeSessionId, resolveHookScriptPath } from "./env.js";
+import { runHookScript } from "./runner.js";
+
 export class HookDecisionError extends Error {
   constructor(message, details = {}) {
     super(message);
@@ -5,6 +11,12 @@ export class HookDecisionError extends Error {
     this.details = details;
   }
 }
+
+const ASK_ALLOW_ONCE = "Allow once";
+const ASK_ALLOW_SESSION = "Allow for rest of this session";
+const ASK_ALLOW_PROJECT = "Always allow in this project";
+const ASK_ALLOW_USER = "Always allow from now on";
+const ASK_DENY = "Deny";
 
 function isObject(value) {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -50,7 +62,215 @@ function notifySystemMessage(ctx, systemMessage) {
   }
 }
 
-async function resolveAskDecision({ reason, ctx, packageRegistration, hookRegistration }) {
+function resolvePermissionDecisionMetadata(hookSpecificOutput) {
+  if (!isObject(hookSpecificOutput)) {
+    return null;
+  }
+
+  const metadata = hookSpecificOutput.permissionDecisionMetadata;
+  return isObject(metadata) ? metadata : null;
+}
+
+function buildDefaultAllowKey({ packageRegistration, hookRegistration, claudePayload, reason }) {
+  const digest = createHash("sha256")
+    .update(
+      JSON.stringify({
+        packageId: packageRegistration?.packageId ?? "",
+        hookId: hookRegistration?.id ?? "",
+        toolName: claudePayload?.tool_name ?? "",
+        toolInput: claudePayload?.tool_input ?? {},
+        reason: reason ?? "",
+      }),
+    )
+    .digest("hex");
+
+  return `hook-compat:${packageRegistration?.packageId ?? "package"}:${hookRegistration?.id ?? "hook"}:${digest.slice(0, 24)}`;
+}
+
+function resolveAllowKey({ metadata, packageRegistration, hookRegistration, claudePayload, reason }) {
+  if (typeof metadata?.allowKey === "string" && metadata.allowKey.trim() !== "") {
+    return metadata.allowKey;
+  }
+
+  return buildDefaultAllowKey({
+    packageRegistration,
+    hookRegistration,
+    claudePayload,
+    reason,
+  });
+}
+
+function resolvePersistenceAction(metadata, scope) {
+  if (!isObject(metadata)) {
+    return null;
+  }
+
+  const fieldName = scope === "project" ? "projectPersistence" : "userPersistence";
+  const action = metadata[fieldName];
+  return isObject(action) ? action : null;
+}
+
+function buildSelectOptions({ allowProject, allowUser }) {
+  const options = [ASK_ALLOW_ONCE, ASK_ALLOW_SESSION];
+  if (allowProject) {
+    options.push(ASK_ALLOW_PROJECT);
+  }
+  if (allowUser) {
+    options.push(ASK_ALLOW_USER);
+  }
+  options.push(ASK_DENY);
+  return options;
+}
+
+function formatAskPrompt(reason) {
+  const trimmed = typeof reason === "string" ? reason.trim() : "";
+  if (!trimmed) {
+    return "Hook confirmation";
+  }
+  return `Hook confirmation\n\n${trimmed}`;
+}
+
+async function executePersistenceAction({ action, ctx, packageRegistration, hookRegistration }) {
+  if (!isObject(action)) {
+    throw new HookDecisionError("Persistence action must be an object.", {
+      packageId: packageRegistration?.packageId,
+      hookId: hookRegistration?.id,
+      action,
+    });
+  }
+
+  const scriptPath = resolveHookScriptPath(packageRegistration.pluginRoot, action.scriptPath);
+  const projectDir = normalizeSpawnCwd(ctx?.cwd);
+  const sessionId = resolveClaudeSessionId(ctx);
+  const env = buildClaudeCompatEnv({
+    pluginRoot: packageRegistration.pluginRoot,
+    projectDir,
+    sessionId,
+    hookEnv: isObject(action.env) ? action.env : undefined,
+  });
+
+  const { output } = await runHookScript({
+    scriptPath,
+    payload: isObject(action.payload) ? action.payload : {},
+    env,
+    cwd: projectDir,
+    timeoutMs:
+      typeof action.timeoutMs === "number" && Number.isFinite(action.timeoutMs)
+        ? action.timeoutMs
+        : hookRegistration?.timeoutMs,
+  });
+
+  if (ctx?.hasUI && typeof ctx?.ui?.notify === "function" && typeof output?.message === "string" && output.message.trim()) {
+    ctx.ui.notify(output.message, "info");
+  }
+
+  return output;
+}
+
+async function resolveAskDecision({
+  reason,
+  ctx,
+  packageRegistration,
+  hookRegistration,
+  runtime,
+  claudePayload,
+  metadata,
+}) {
+  const allowKey = resolveAllowKey({
+    metadata,
+    packageRegistration,
+    hookRegistration,
+    claudePayload,
+    reason,
+  });
+
+  if (hasSessionAllow(runtime, ctx, allowKey)) {
+    return {
+      block: false,
+      decision: "allow",
+    };
+  }
+
+  const projectPersistence = resolvePersistenceAction(metadata, "project");
+  const userPersistence = resolvePersistenceAction(metadata, "user");
+
+  if (ctx?.hasUI && typeof ctx?.ui?.select === "function") {
+    const choice = await ctx.ui.select(
+      formatAskPrompt(reason ?? "Hook requested confirmation."),
+      buildSelectOptions({
+        allowProject: Boolean(projectPersistence),
+        allowUser: Boolean(userPersistence),
+      }),
+    );
+
+    if (choice === ASK_ALLOW_ONCE) {
+      return {
+        block: false,
+        decision: "allow",
+      };
+    }
+
+    if (choice === ASK_ALLOW_SESSION) {
+      grantSessionAllow(runtime, ctx, allowKey);
+      return {
+        block: false,
+        decision: "allow",
+      };
+    }
+
+    if (choice === ASK_ALLOW_PROJECT) {
+      try {
+        await executePersistenceAction({
+          action: projectPersistence,
+          ctx,
+          packageRegistration,
+          hookRegistration,
+        });
+      } catch (error) {
+        return {
+          block: true,
+          decision: "deny",
+          reason: `Failed to persist project allow: ${error instanceof Error ? error.message : String(error)}`,
+        };
+      }
+
+      grantSessionAllow(runtime, ctx, allowKey);
+      return {
+        block: false,
+        decision: "allow",
+      };
+    }
+
+    if (choice === ASK_ALLOW_USER) {
+      try {
+        await executePersistenceAction({
+          action: userPersistence,
+          ctx,
+          packageRegistration,
+          hookRegistration,
+        });
+      } catch (error) {
+        return {
+          block: true,
+          decision: "deny",
+          reason: `Failed to persist user allow: ${error instanceof Error ? error.message : String(error)}`,
+        };
+      }
+
+      grantSessionAllow(runtime, ctx, allowKey);
+      return {
+        block: false,
+        decision: "allow",
+      };
+    }
+
+    return {
+      block: true,
+      decision: "deny",
+      reason: reason ? `Blocked by user: ${reason}` : "Blocked by user.",
+    };
+  }
+
   if (ctx?.hasUI && typeof ctx?.ui?.confirm === "function") {
     const approved = await ctx.ui.confirm("Hook confirmation", reason ?? "Hook requested confirmation.");
     if (approved) {
@@ -83,7 +303,14 @@ async function resolveAskDecision({ reason, ctx, packageRegistration, hookRegist
   };
 }
 
-export async function interpretHookDecision({ output, ctx, packageRegistration, hookRegistration }) {
+export async function interpretHookDecision({
+  output,
+  ctx,
+  packageRegistration,
+  hookRegistration,
+  runtime,
+  claudePayload,
+}) {
   if (output === null || output === undefined) {
     return {
       block: false,
@@ -133,6 +360,7 @@ export async function interpretHookDecision({ output, ctx, packageRegistration, 
     typeof hookSpecificOutput.permissionDecisionReason === "string"
       ? hookSpecificOutput.permissionDecisionReason
       : undefined;
+  const metadata = resolvePermissionDecisionMetadata(hookSpecificOutput);
 
   if (decision === "allow") {
     notifySystemMessage(ctx, systemMessage);
@@ -161,6 +389,9 @@ export async function interpretHookDecision({ output, ctx, packageRegistration, 
       ctx,
       packageRegistration,
       hookRegistration,
+      runtime,
+      claudePayload,
+      metadata,
     });
   }
 
@@ -170,3 +401,5 @@ export async function interpretHookDecision({ output, ctx, packageRegistration, 
     hookId: hookRegistration.id,
   });
 }
+
+export { clearHookCompatAllowState };

--- a/packages/pi-compat/extensions/hook-compat/index.js
+++ b/packages/pi-compat/extensions/hook-compat/index.js
@@ -1,3 +1,4 @@
+import { clearHookCompatAllowState } from "./decision.js";
 import { clearHookCompatRuntimeState, markHookCompatRuntimeInstalled } from "./registry.js";
 import { runHookCompatPreflight, runHookCompatToolCall } from "./runtime.js";
 
@@ -39,6 +40,7 @@ export default function hookCompatExtension(pi) {
   });
 
   pi.on("session_shutdown", async () => {
+    clearHookCompatAllowState(pi);
     clearHookCompatRuntimeState(pi);
   });
 }

--- a/packages/pi-compat/extensions/hook-compat/runtime.js
+++ b/packages/pi-compat/extensions/hook-compat/runtime.js
@@ -55,7 +55,7 @@ function normalizePreflightToolName(toolName) {
   return toolName;
 }
 
-async function executeHookCompatPreflight({ claudePayload, ctx, projectDir, sessionId, registrations }) {
+async function executeHookCompatPreflight({ claudePayload, ctx, projectDir, sessionId, registrations, runtime }) {
   for (const packageRegistration of registrations) {
     for (const hookGroup of packageRegistration.hooks) {
       if (!matchesClaudeMatcher(hookGroup.matcher, claudePayload.tool_name)) {
@@ -86,6 +86,8 @@ async function executeHookCompatPreflight({ claudePayload, ctx, projectDir, sess
             ctx,
             packageRegistration,
             hookRegistration,
+            runtime,
+            claudePayload,
           });
 
           if (decision.block) {
@@ -135,6 +137,7 @@ export async function runHookCompatPreflight({ toolName, input, cwd, ctx, runtim
       projectDir,
       sessionId,
       registrations: effectiveRegistrations,
+      runtime,
     });
   } catch (error) {
     return {

--- a/packages/pi-compat/extensions/hook-compat/tests/helpers.js
+++ b/packages/pi-compat/extensions/hook-compat/tests/helpers.js
@@ -31,9 +31,17 @@ export function createToolCallEvent(toolName, input) {
   };
 }
 
-export function createTestContext({ cwd, hasUI, confirmResult = true, sessionId = "hook-compat-test-session" }) {
+export function createTestContext({
+  cwd,
+  hasUI,
+  confirmResult = true,
+  selectResult,
+  sessionId = "hook-compat-test-session",
+  branchEntries = [],
+}) {
   const notifications = [];
   const confirmations = [];
+  const selections = [];
 
   const ui = {
     notify(message, level) {
@@ -46,6 +54,16 @@ export function createTestContext({ cwd, hasUI, confirmResult = true, sessionId 
       }
       return Boolean(confirmResult);
     },
+    async select(prompt, options) {
+      selections.push({ prompt, options: [...options] });
+      if (typeof selectResult === "function") {
+        return await selectResult({ prompt, options: [...options], selections: [...selections] });
+      }
+      if (selectResult !== undefined) {
+        return selectResult;
+      }
+      return options[0];
+    },
   };
 
   const ctx = {
@@ -55,6 +73,9 @@ export function createTestContext({ cwd, hasUI, confirmResult = true, sessionId 
       getSessionId() {
         return sessionId;
       },
+      getBranch() {
+        return branchEntries;
+      },
     },
     ui,
   };
@@ -63,6 +84,8 @@ export function createTestContext({ cwd, hasUI, confirmResult = true, sessionId 
     ctx,
     notifications,
     confirmations,
+    selections,
+    branchEntries,
   };
 }
 

--- a/packages/pi-compat/extensions/hook-compat/tests/package-wired-registrations.test.js
+++ b/packages/pi-compat/extensions/hook-compat/tests/package-wired-registrations.test.js
@@ -5,6 +5,7 @@ import { join, resolve } from "node:path";
 import test from "node:test";
 
 import { listRegisteredHookCompatPackages } from "../index.js";
+import { resetHookCompatAllowStateForTests } from "../allow-state.js";
 import { resetHookCompatRegistryForTests } from "../registry.js";
 import { runHookCompatPreflight, runHookCompatToolCall } from "../runtime.js";
 import {
@@ -59,8 +60,17 @@ async function withTemporaryEnv(overrides, fn) {
   }
 }
 
-function createRuntime(name) {
-  return { name };
+function createRuntime(name, branchEntries = []) {
+  return {
+    name,
+    appendEntry(customType, data) {
+      branchEntries.push({
+        type: "custom",
+        customType,
+        data,
+      });
+    },
+  };
 }
 
 test("package extensions register packaged asset roots and expected hook tables", async () => {
@@ -388,6 +398,108 @@ test(
       });
     } finally {
       await cleanupPath(workspace.rootDir);
+      resetHookCompatRegistryForTests();
+    }
+  },
+);
+
+test(
+  "package-wired safety ask flow can remember approval for the rest of the session",
+  { skip: !UV_IS_AVAILABLE, concurrency: false },
+  async () => {
+    resetHookCompatAllowStateForTests();
+    resetHookCompatRegistryForTests();
+    const workspace = await createRuntimeWorkspace("phase007-safety-session-allow");
+
+    try {
+      await withTemporaryEnv({ HOME: workspace.homeDir, UV_CACHE_DIR }, async () => {
+        const branchEntries = [];
+        const runtime = createRuntime("safety-runtime-session-allow", branchEntries);
+        registerAcSafetyHookCompat(runtime);
+
+        const interactiveContext = createTestContext({
+          cwd: workspace.projectDir,
+          hasUI: true,
+          selectResult: ({ selections }) => (selections.length === 1 ? "Allow for rest of this session" : "Deny"),
+          branchEntries,
+        });
+
+        const firstResult = await runHookCompatToolCall(
+          createToolCallEvent("bash", { command: 'playwright-cli eval "document.title"' }),
+          interactiveContext.ctx,
+          { runtime },
+        );
+        assert.equal(firstResult, undefined);
+        assert.equal(interactiveContext.selections.length, 1);
+        assert.equal(branchEntries.length, 1);
+        assert.equal(branchEntries[0]?.customType, "hook-compat-allow");
+
+        const secondResult = await runHookCompatToolCall(
+          createToolCallEvent("bash", { command: 'playwright-cli eval "document.title"' }),
+          interactiveContext.ctx,
+          { runtime },
+        );
+        assert.equal(secondResult, undefined);
+        assert.equal(interactiveContext.selections.length, 1);
+      });
+    } finally {
+      await cleanupPath(workspace.rootDir);
+      resetHookCompatAllowStateForTests();
+      resetHookCompatRegistryForTests();
+    }
+  },
+);
+
+test(
+  "package-wired safety ask flow can persist project allowlists for exact Playwright actions",
+  { skip: !UV_IS_AVAILABLE, concurrency: false },
+  async () => {
+    resetHookCompatAllowStateForTests();
+    resetHookCompatRegistryForTests();
+    const workspace = await createRuntimeWorkspace("phase007-safety-project-allow");
+
+    try {
+      await withTemporaryEnv({ HOME: workspace.homeDir, UV_CACHE_DIR }, async () => {
+        const branchEntries = [];
+        const runtime = createRuntime("safety-runtime-project-allow", branchEntries);
+        registerAcSafetyHookCompat(runtime);
+
+        const interactiveContext = createTestContext({
+          cwd: workspace.projectDir,
+          hasUI: true,
+          selectResult: "Always allow in this project",
+          branchEntries,
+        });
+
+        const firstResult = await runHookCompatToolCall(
+          createToolCallEvent("bash", { command: 'playwright-cli eval "document.title"' }),
+          interactiveContext.ctx,
+          { runtime },
+        );
+        assert.equal(firstResult, undefined);
+        assert.equal(interactiveContext.selections.length, 1);
+
+        const persistedConfig = await readFile(resolve(workspace.projectDir, "safety.yaml"), "utf8");
+        assert.match(persistedConfig, /allowed_cli_actions:/);
+        assert.match(persistedConfig, /- eval/);
+
+        const freshRuntime = createRuntime("safety-runtime-project-allow-fresh", []);
+        registerAcSafetyHookCompat(freshRuntime);
+        const nonInteractiveContext = createTestContext({
+          cwd: workspace.projectDir,
+          hasUI: false,
+          branchEntries: [],
+        });
+        const secondResult = await runHookCompatToolCall(
+          createToolCallEvent("bash", { command: 'playwright-cli eval "document.title"' }),
+          nonInteractiveContext.ctx,
+          { runtime: freshRuntime },
+        );
+        assert.equal(secondResult, undefined);
+      });
+    } finally {
+      await cleanupPath(workspace.rootDir);
+      resetHookCompatAllowStateForTests();
       resetHookCompatRegistryForTests();
     }
   },

--- a/packages/pi-compat/extensions/hook-compat/tests/runtime-representative-scripts.test.js
+++ b/packages/pi-compat/extensions/hook-compat/tests/runtime-representative-scripts.test.js
@@ -111,7 +111,7 @@ test(
       const deniedByUser = createTestContext({
         cwd: workspace.projectDir,
         hasUI: true,
-        confirmResult: false,
+        selectResult: "Deny",
       });
 
       const deniedResult = await runHookCompatToolCall(
@@ -122,12 +122,12 @@ test(
 
       assert.equal(deniedResult?.block, true);
       assert.match(deniedResult?.reason ?? "", /Blocked by user|confirm to proceed/i);
-      assert.equal(deniedByUser.confirmations.length, 1);
+      assert.equal(deniedByUser.selections.length, 1);
 
       const allowedByUser = createTestContext({
         cwd: workspace.projectDir,
         hasUI: true,
-        confirmResult: true,
+        selectResult: "Allow once",
       });
 
       const allowedResult = await runHookCompatToolCall(


### PR DESCRIPTION
## Summary

Adds scoped approvals for hook asks used by `hook-compat` and `ac-safety`, so users can allow once, for the session, in the project, or globally with narrow persistence.

- replace yes/no hook confirmation with scoped approval choices
- remember repeated approvals for the rest of the session
- persist narrow allow rules for exact Playwright actions/domains and selected supply-chain allowlists

### Root Cause

Hook asks only supported yes/no confirmation. That made repeated approvals noisy and forced broad config overrides when users wanted persistent allow behavior. The `playwright-cli eval` case exposed the gap because it needed an exact-action allow path rather than a coarse category override.

### Key Changes

**Shared hook runtime:**
- add session-scoped allow memory in `hook-compat`
- support package-provided project/user persistence actions
- update hook-compat docs and tests for scoped approvals

**ac-safety:**
- add `persist-allow.py` to merge narrow overrides into `safety.yaml`
- emit persistence metadata from Playwright and supply-chain guardians
- add explicit `playwright.allowed_cli_actions` and `playwright.allowed_mcp_actions`

## Test Plan

- [x] `uv run ruff check --fix packages/pi-ac-safety/assets/scripts/hooks/_lib.py packages/pi-ac-safety/assets/scripts/hooks/playwright-guardian.py packages/pi-ac-safety/assets/scripts/hooks/supply-chain-guardian.py packages/pi-ac-safety/assets/scripts/hooks/persist-allow.py`
- [x] `uv run pyright packages/pi-ac-safety/assets/scripts/hooks/_lib.py packages/pi-ac-safety/assets/scripts/hooks/playwright-guardian.py packages/pi-ac-safety/assets/scripts/hooks/supply-chain-guardian.py packages/pi-ac-safety/assets/scripts/hooks/persist-allow.py`
- [x] `node --test packages/pi-compat/extensions/hook-compat/tests/*.test.js`

## Files Changed

**hook-compat:**
- `packages/pi-compat/extensions/hook-compat/decision.js` - scoped ask flow and persistence execution
- `packages/pi-compat/extensions/hook-compat/allow-state.js` - session-scoped approval memory
- `packages/pi-compat/extensions/hook-compat/runtime.js`, `index.js`, `README.md` - runtime wiring and docs
- `packages/pi-compat/extensions/hook-compat/tests/*` - coverage for session and project approvals

**ac-safety:**
- `packages/pi-ac-safety/assets/scripts/hooks/persist-allow.py` - writes narrow `safety.yaml` overrides
- `packages/pi-ac-safety/assets/scripts/hooks/playwright-guardian.py` - exact action/domain persistence metadata
- `packages/pi-ac-safety/assets/scripts/hooks/supply-chain-guardian.py` - narrow allowlist persistence metadata
- `packages/pi-ac-safety/assets/scripts/hooks/_lib.py` and `packages/pi-ac-safety/assets/config/safety.default.yaml` - merge support and new allowlist keys

## Related

- **Spec**: `.specs/specs/2026/04/feat/hook-allow-scopes/000-backlog.md`

Generated with pi