### PR TITLE
docs(changelog): add Unreleased entry for scoped hook approvals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to agentic-config.
 
 ## [Unreleased]
 
+### Added
+
+- `pi-compat`, `pi-ac-safety`: scoped hook approval persistence for safety ask flows
+  - adds once/session/project/user approval scopes in `hook-compat`
+  - persists narrow `safety.yaml` allow rules for exact Playwright actions/domains and selected supply-chain allowlists
+
 ## [0.3.0-alpha] - 2026-04-21
 
 ### Added


### PR DESCRIPTION
## Summary

Adds the missing `CHANGELOG.md` entry for the already-merged scoped hook approval work.

- records the Unreleased changelog note for `pi-compat` and `pi-ac-safety`
- captures the new once/session/project/user approval scopes and narrow safety persistence behavior

## Test Plan

- [x] `git diff --check`

## Files Changed

**Documentation:**
- `CHANGELOG.md` - add the missing Unreleased entry for scoped hook approvals

## Related

- **Spec**: `.specs/specs/2026/04/docs/changelog-scoped-hook-approvals/000-backlog.md`
- **Previous PR**: `#77`

Generated with pi