### PR TITLE
fix(pimux): harden closeout delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ All notable changes to agentic-config.
 ### Added
 
 - `pi-ac-workflow`: add deterministic `pimux activity` checks and correlated `ping_agent` liveness probes for managed agents.
+- `pi-ac-workflow`: add behavioral parent-delivery coverage for retry, ack ordering, terminal notification dedupe, watchdog throttling, and ping gating.
 
 ### Changed
 
 - `pi-ac-workflow`: harden `pimux` parent bridge delivery for bursty terminal closeouts with batched notifications, retryable terminal notification state, bridge-delivery reconciliation, and inactivity watchdog alerts.
+  - persists parent-delivery acknowledgements only after successful sends and requeues pending deliveries when queued-state persistence or sends fail
+  - allows `pimux activity` as final settlement verification alongside `status`
+  - allows `pimux open` during supervision only when the user explicitly asks to watch live, while routine polling checks remain blocked
 
 ## [0.3.0] - 2026-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to agentic-config.
 
 ## [Unreleased]
 
+### Added
+
+- `pi-ac-workflow`: add deterministic `pimux activity` checks and correlated `ping_agent` liveness probes for managed agents.
+
+### Changed
+
+- `pi-ac-workflow`: harden `pimux` parent bridge delivery for bursty terminal closeouts with batched notifications, retryable terminal notification state, bridge-delivery reconciliation, and inactivity watchdog alerts.
+
 ## [0.3.0] - 2026-04-30
 
 ### Added

--- a/packages/pi-ac-workflow/extensions/pimux/TESTING.md
+++ b/packages/pi-ac-workflow/extensions/pimux/TESTING.md
@@ -43,6 +43,10 @@ The current pytest surface covers these areas:
   - notification surface behavior
 - `tests/test_pimux_skill_surface.py`
   - skill and command-surface expectations
+- terminal delivery hardening checks
+  - batched parent delivery queue surface
+  - retryable terminal notification metadata
+  - deterministic `activity` and correlated `ping_agent` command/tool exposure
 
 ## Focused targeted reruns used during implementation
 
@@ -103,7 +107,7 @@ When modifying files under `packages/pi-ac-workflow/extensions/pimux/` (or the p
 
 1. run the focused tests relevant to the changed surface
 2. run the full regression command
-3. if the change touches routing, settlement, shutdown, or nested orchestration behavior, run at least one real live smoke scenario with headless agents
+3. if the change touches routing, settlement, shutdown, watchdogs, activity probes, or nested orchestration behavior, run at least one real live smoke scenario with headless agents
 4. record any important new runtime findings in a local `tmp/` artifact during investigation, then update this document if the persistent validation story changes
 
 ## Wrapper clean-exit guidance

--- a/packages/pi-ac-workflow/extensions/pimux/TESTING.md
+++ b/packages/pi-ac-workflow/extensions/pimux/TESTING.md
@@ -12,9 +12,9 @@ pytest -q tests/test_pimux_*.py
 
 Latest observed result:
 
-- Date: 2026-04-13
-- Result: `44 passed in 2.29s`
-- Notes: includes the wrapper clean-exit guidance follow-up checks
+- Date: 2026-05-01
+- Result: `93 passed in 9.03s`
+- Notes: includes parent-delivery retry/ack behavior, live-open guard behavior, and wrapper clean-exit guidance checks
 
 ## Automated test coverage
 
@@ -41,6 +41,11 @@ The current pytest surface covers these areas:
   - authoritative child binding rules
 - `tests/test_pimux_notification_surface.py`
   - notification surface behavior
+- `tests/test_pimux_parent_delivery_behavior.py`
+  - parent-delivery flush retry and ack ordering
+  - terminal notification dedupe
+  - inactivity watchdog throttling
+  - `ping_agent` probe gating
 - `tests/test_pimux_skill_surface.py`
   - skill and command-surface expectations
 - terminal delivery hardening checks

--- a/packages/pi-ac-workflow/extensions/pimux/bridge.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/bridge.ts
@@ -74,7 +74,12 @@ export interface BridgeParentState {
 	deliveredEventIds: string[];
 	terminalEventId?: string;
 	terminalFinalizedAt?: string;
+	terminalObservedAt?: string;
 	terminalState?: SettledTerminalState;
+	terminalNotificationQueuedAt?: string;
+	terminalNotificationDeliveredAt?: string;
+	terminalNotificationBatchId?: string;
+	terminalNotificationAttemptCount?: number;
 	protocolViolationReason?: string;
 	updatedAt?: string;
 }
@@ -150,7 +155,12 @@ function mergeBridgeParentState(current: BridgeParentState, next: BridgeParentSt
 		deliveredEventIds: uniqueStrings([...(current.deliveredEventIds ?? []), ...(next.deliveredEventIds ?? [])]),
 		terminalEventId: next.terminalEventId ?? current.terminalEventId,
 		terminalFinalizedAt: preferLatestIso(current.terminalFinalizedAt, next.terminalFinalizedAt),
+		terminalObservedAt: preferLatestIso(current.terminalObservedAt, next.terminalObservedAt),
 		terminalState: next.terminalState ?? current.terminalState,
+		terminalNotificationQueuedAt: preferLatestIso(current.terminalNotificationQueuedAt, next.terminalNotificationQueuedAt),
+		terminalNotificationDeliveredAt: preferLatestIso(current.terminalNotificationDeliveredAt, next.terminalNotificationDeliveredAt),
+		terminalNotificationBatchId: next.terminalNotificationBatchId ?? current.terminalNotificationBatchId,
+		terminalNotificationAttemptCount: Math.max(current.terminalNotificationAttemptCount ?? 0, next.terminalNotificationAttemptCount ?? 0),
 		protocolViolationReason: next.protocolViolationReason ?? current.protocolViolationReason,
 	};
 }
@@ -382,6 +392,7 @@ export function buildChildProtocol(launch: BridgeLaunchFile): string {
 		"- FIRST: do not poll pimux and do not use Bash sleep/wait loops; wait for delivered child activity.",
 		"- Work on the assigned mission normally.",
 		"- Parent -> child messaging uses pimux send_message and arrives through the bridge inbox.",
+		"- A parent status_request is a liveness probe: reply promptly with report_parent(progress) if still working, or emit closeout/blocker/failure if terminal.",
 		"- Child -> parent reporting uses pimux report_parent only from this authoritative direct child session.",
 		"- If you launch local helpers or subagents, they are local-only and must not call pimux or report_parent.",
 		"- If you act as an orchestrator, you own the control-plane for your subtree.",

--- a/packages/pi-ac-workflow/extensions/pimux/bridge.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/bridge.ts
@@ -152,7 +152,7 @@ function mergeBridgeParentState(current: BridgeParentState, next: BridgeParentSt
 	return {
 		...current,
 		...next,
-		deliveredEventIds: uniqueStrings([...(current.deliveredEventIds ?? []), ...(next.deliveredEventIds ?? [])]),
+		deliveredEventIds: uniqueStrings([...(current.deliveredEventIds ?? []), ...(next.deliveredEventIds ?? [])]).slice(-500),
 		terminalEventId: next.terminalEventId ?? current.terminalEventId,
 		terminalFinalizedAt: preferLatestIso(current.terminalFinalizedAt, next.terminalFinalizedAt),
 		terminalObservedAt: preferLatestIso(current.terminalObservedAt, next.terminalObservedAt),

--- a/packages/pi-ac-workflow/extensions/pimux/control-plane.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/control-plane.ts
@@ -85,6 +85,7 @@ const MUX_OSPEC_MODIFIERS = new Set([
 const POST_SPAWN_ALLOWED_ACTIONS = new Set(["spawn", "status", "activity", "capture", "tree", "list", "send_message", "ping_agent", "open", "kill"]);
 const SUPERVISION_CHECK_ACTIONS = new Set(["status", "activity", "capture", "tree", "list", "open"]);
 const SUPERVISION_RECOVERY_ACTIONS = new Set(["send_message", "ping_agent"]);
+const SETTLEMENT_VERIFICATION_ACTIONS = new Set(["status", "activity"]);
 const UNRESTRICTED_POST_SPAWN_ACTIONS = new Set(["spawn", "kill"]);
 const BASH_WAIT_LOOP_PATTERN = /\b(?:while|until|for)\b[\s\S]*\b(?:sleep|wait)\b/i;
 const BASH_SLEEP_OR_WAIT_PATTERN = /(?:^|[\s;&|()])(?:sleep\s+\d+(?:\.\d+)?|wait)(?:\s|[;&|)]|$)/i;
@@ -442,6 +443,10 @@ function isRecoveryAction(action: string): boolean {
 	return SUPERVISION_RECOVERY_ACTIONS.has(action);
 }
 
+function isSettlementVerificationAction(action: string): boolean {
+	return SETTLEMENT_VERIFICATION_ACTIONS.has(action);
+}
+
 function isTrackedDirectChild(lock: ControlPlaneLockState, agentId?: string): boolean {
 	return !lock.lastSpawnedAgentId || !agentId || lock.lastSpawnedAgentId === agentId;
 }
@@ -558,9 +563,9 @@ export function evaluateNoPollingSupervisionToolCall(
 	if (isPimuxTool(event.toolName)) {
 		const action = String(event.input?.action ?? "").trim();
 		if (!action || !isSupervisionCheckAction(action)) return { allow: true };
-		if (supervision.settlementVerificationPending && action === "status") return { allow: true };
+		if (supervision.settlementVerificationPending && isSettlementVerificationAction(action)) return { allow: true };
 		if (supervision.settlementVerificationPending) {
-			return buildNoPollingReason("Terminal settlement is ready. Use one final pimux status check, then stop supervising this child.");
+			return buildNoPollingReason("Terminal settlement is ready. Use one final pimux status or activity check, then stop supervising this child.");
 		}
 		if (isInactivityWatchdogReached(supervision, now)) return { allow: true };
 		return buildNoPollingReason(
@@ -646,12 +651,12 @@ export function evaluateControlPlaneToolCall(
 	}
 
 	if (lock.settlementVerificationPending) {
-		if (action === "status") {
+		if (isSettlementVerificationAction(action)) {
 			return { allow: true };
 		}
 		return buildNotifyFirstReason(
 			lock,
-			"Terminal settlement is ready. Use one final pimux status check, then stop supervising this child.",
+			"Terminal settlement is ready. Use one final pimux status or activity check, then stop supervising this child.",
 		);
 	}
 
@@ -694,7 +699,7 @@ export function updateNoPollingSupervisionForToolResult(
 	const action = String(event.details?.action ?? "").trim();
 	if (!action || event.isError || typeof event.details?.error === "string") return supervision;
 	const occurredAt = resolveNowIso(now);
-	if (supervision.settlementVerificationPending && action === "status") {
+	if (supervision.settlementVerificationPending && isSettlementVerificationAction(action)) {
 		return {
 			...supervision,
 			active: false,
@@ -741,7 +746,7 @@ export function updateControlPlaneLockForToolResult(
 
 	if (lock.phase !== "post_spawn") return lock;
 
-	if (lock.settlementVerificationPending && action === "status") {
+	if (lock.settlementVerificationPending && isSettlementVerificationAction(action)) {
 		return {
 			...lock,
 			lastSupervisionResetAt: occurredAt,
@@ -932,7 +937,7 @@ export function buildControlPlaneSystemPrompt(lock: ControlPlaneLockState | unde
 		lines.push(
 			`- Use status/activity/capture/tree/list/open only for explicit live inspection, suspected stall/protocol violation/failure, terminal settlement verification, or the ${CONTROL_PLANE_INACTIVITY_WATCHDOG_LABEL} inactivity watchdog.`,
 		);
-		lines.push("- after terminal settlement, use one final pimux status check before advancing.");
+		lines.push("- after terminal settlement, use one final pimux status or activity check before advancing.");
 	}
 	if (lock.mode === "mux-ospec" || lock.mode === "mux-roadmap") {
 		if (lock.specPath) {

--- a/packages/pi-ac-workflow/extensions/pimux/control-plane.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/control-plane.ts
@@ -92,6 +92,11 @@ const BASH_SLEEP_OR_WAIT_PATTERN = /(?:^|[\s;&|()])(?:sleep\s+\d+(?:\.\d+)?|wait
 const ROADMAP_CONTROL_TOKENS = new Set(["START", "CONTINUE"]);
 export const CONTROL_PLANE_INACTIVITY_WATCHDOG_MS = 10 * 60_000;
 const CONTROL_PLANE_INACTIVITY_WATCHDOG_LABEL = "10m";
+const SUPERVISION_CHECK_RECOVERY_DETAIL = `status/activity/capture/tree/list/open are recovery-only; open is also allowed when the user explicitly asks to watch live. Other check actions are allowed only after terminal settlement or the ${CONTROL_PLANE_INACTIVITY_WATCHDOG_LABEL} inactivity watchdog.`;
+
+export interface ControlPlaneToolContext {
+	explicitLiveInspectionRequested?: boolean;
+}
 
 interface BranchSpecEntry {
 	year: string;
@@ -443,6 +448,10 @@ function isRecoveryAction(action: string): boolean {
 	return SUPERVISION_RECOVERY_ACTIONS.has(action);
 }
 
+function isExplicitOpenAction(action: string, context?: ControlPlaneToolContext): boolean {
+	return action === "open" && context?.explicitLiveInspectionRequested === true;
+}
+
 function isSettlementVerificationAction(action: string): boolean {
 	return SETTLEMENT_VERIFICATION_ACTIONS.has(action);
 }
@@ -553,23 +562,30 @@ function buildRestrictedReason(lock: ControlPlaneLockState, detail: string): str
 	return `Explicit ${lock.mode ?? "mux-family"} parent is control-plane locked. ${detail}`;
 }
 
+export function isExplicitLiveInspectionRequest(text: string | undefined): boolean {
+	const value = String(text ?? "").toLowerCase();
+	return /\b(open|show|watch|view)\b/.test(value) && /\b(live|tab|tabs|iterm|terminal|tmux)\b/.test(value);
+}
+
 export function evaluateNoPollingSupervisionToolCall(
 	supervision: NoPollingSupervisionState | undefined,
 	event: { toolName?: string; input?: Record<string, unknown> },
 	now?: string | number,
+	context?: ControlPlaneToolContext,
 ): ControlPlaneToolDecision {
 	if (!supervision?.active) return { allow: true };
 
 	if (isPimuxTool(event.toolName)) {
 		const action = String(event.input?.action ?? "").trim();
 		if (!action || !isSupervisionCheckAction(action)) return { allow: true };
+		if (isExplicitOpenAction(action, context)) return { allow: true };
 		if (supervision.settlementVerificationPending && isSettlementVerificationAction(action)) return { allow: true };
 		if (supervision.settlementVerificationPending) {
 			return buildNoPollingReason("Terminal settlement is ready. Use one final pimux status or activity check, then stop supervising this child.");
 		}
 		if (isInactivityWatchdogReached(supervision, now)) return { allow: true };
 		return buildNoPollingReason(
-			`Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the ${CONTROL_PLANE_INACTIVITY_WATCHDOG_LABEL} inactivity watchdog.`,
+			`Do not poll pimux; wait for delivered child activity. ${SUPERVISION_CHECK_RECOVERY_DETAIL}`,
 		);
 	}
 
@@ -586,6 +602,7 @@ export function evaluateControlPlaneToolCall(
 	lock: ControlPlaneLockState | undefined,
 	event: { toolName?: string; input?: Record<string, unknown> },
 	now?: string | number,
+	context?: ControlPlaneToolContext,
 ): ControlPlaneToolDecision {
 	if (!lock?.active || !lock.mode || !lock.phase) {
 		return { allow: true };
@@ -650,6 +667,10 @@ export function evaluateControlPlaneToolCall(
 		return { allow: true };
 	}
 
+	if (isExplicitOpenAction(action, context)) {
+		return { allow: true };
+	}
+
 	if (lock.settlementVerificationPending) {
 		if (isSettlementVerificationAction(action)) {
 			return { allow: true };
@@ -666,7 +687,7 @@ export function evaluateControlPlaneToolCall(
 		}
 		return buildNotifyFirstReason(
 			lock,
-			`Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the ${CONTROL_PLANE_INACTIVITY_WATCHDOG_LABEL} inactivity watchdog.`,
+			`Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. ${SUPERVISION_CHECK_RECOVERY_DETAIL}`,
 		);
 	}
 
@@ -927,15 +948,15 @@ export function buildControlPlaneSystemPrompt(lock: ControlPlaneLockState | unde
 		"- parent may use only pimux, AskUserQuestion, and say while this lock is active.",
 		lock.phase === "pre_spawn"
 			? "- Phase A before first child report: the only allowed pimux action is spawn."
-			: "- Phase B/C after spawn: wait for delivered child reports; send_message/ping_agent only after child activity; status/activity/capture/tree/list/open are recovery-only.",
+			: "- Phase B/C after spawn: wait for delivered child reports; send_message/ping_agent only after child activity; status/activity/capture/tree/list/open are recovery-only, except open when the user explicitly asks to watch live.",
 		"- do not use parent-side Read/Bash/Edit/Write/NotebookEdit/Grep/Glob/web_search/subagent for repo work.",
 	];
 	if (lock.phase === "post_spawn") {
 		lines.push("- PIMUX HAPPY-PATH DISCIPLINE: this run is notify-first, not poll-first.");
-		lines.push("- Do not poll pimux or use Bash sleep/wait loops; wait for delivered child activity, and treat status/activity/capture/tree/list/open as recovery-only.");
+		lines.push("- Do not poll pimux or use Bash sleep/wait loops; wait for delivered child activity, and treat status/activity/capture/tree/list/open as recovery-only; open is also allowed when the user explicitly asks to watch live.");
 		lines.push("- Allowed happy-path sequence: spawn -> wait for child report -> send_message once if needed -> wait for closeout -> final status verification.");
 		lines.push(
-			`- Use status/activity/capture/tree/list/open only for explicit live inspection, suspected stall/protocol violation/failure, terminal settlement verification, or the ${CONTROL_PLANE_INACTIVITY_WATCHDOG_LABEL} inactivity watchdog.`,
+			`- Use status/activity/capture/tree/list/open only for suspected stall/protocol violation/failure, terminal settlement verification, or the ${CONTROL_PLANE_INACTIVITY_WATCHDOG_LABEL} inactivity watchdog; open is also allowed when the user explicitly asks to watch live.`,
 		);
 		lines.push("- after terminal settlement, use one final pimux status or activity check before advancing.");
 	}

--- a/packages/pi-ac-workflow/extensions/pimux/control-plane.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/control-plane.ts
@@ -82,9 +82,9 @@ const MUX_OSPEC_MODIFIERS = new Set([
 	"SELF_VALIDATION",
 ]);
 
-const POST_SPAWN_ALLOWED_ACTIONS = new Set(["spawn", "status", "capture", "tree", "list", "send_message", "open", "kill"]);
-const SUPERVISION_CHECK_ACTIONS = new Set(["status", "capture", "tree", "list", "open"]);
-const SUPERVISION_RECOVERY_ACTIONS = new Set(["send_message"]);
+const POST_SPAWN_ALLOWED_ACTIONS = new Set(["spawn", "status", "activity", "capture", "tree", "list", "send_message", "ping_agent", "open", "kill"]);
+const SUPERVISION_CHECK_ACTIONS = new Set(["status", "activity", "capture", "tree", "list", "open"]);
+const SUPERVISION_RECOVERY_ACTIONS = new Set(["send_message", "ping_agent"]);
 const UNRESTRICTED_POST_SPAWN_ACTIONS = new Set(["spawn", "kill"]);
 const BASH_WAIT_LOOP_PATTERN = /\b(?:while|until|for)\b[\s\S]*\b(?:sleep|wait)\b/i;
 const BASH_SLEEP_OR_WAIT_PATTERN = /(?:^|[\s;&|()])(?:sleep\s+\d+(?:\.\d+)?|wait)(?:\s|[;&|)]|$)/i;
@@ -564,7 +564,7 @@ export function evaluateNoPollingSupervisionToolCall(
 		}
 		if (isInactivityWatchdogReached(supervision, now)) return { allow: true };
 		return buildNoPollingReason(
-			`Do not poll pimux; wait for delivered child activity. status/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the ${CONTROL_PLANE_INACTIVITY_WATCHDOG_LABEL} inactivity watchdog.`,
+			`Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the ${CONTROL_PLANE_INACTIVITY_WATCHDOG_LABEL} inactivity watchdog.`,
 		);
 	}
 
@@ -661,7 +661,7 @@ export function evaluateControlPlaneToolCall(
 		}
 		return buildNotifyFirstReason(
 			lock,
-			`Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the ${CONTROL_PLANE_INACTIVITY_WATCHDOG_LABEL} inactivity watchdog.`,
+			`Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the ${CONTROL_PLANE_INACTIVITY_WATCHDOG_LABEL} inactivity watchdog.`,
 		);
 	}
 
@@ -922,15 +922,15 @@ export function buildControlPlaneSystemPrompt(lock: ControlPlaneLockState | unde
 		"- parent may use only pimux, AskUserQuestion, and say while this lock is active.",
 		lock.phase === "pre_spawn"
 			? "- Phase A before first child report: the only allowed pimux action is spawn."
-			: "- Phase B/C after spawn: wait for delivered child reports; send_message only after child activity; status/capture/tree/list/open are recovery-only.",
+			: "- Phase B/C after spawn: wait for delivered child reports; send_message/ping_agent only after child activity; status/activity/capture/tree/list/open are recovery-only.",
 		"- do not use parent-side Read/Bash/Edit/Write/NotebookEdit/Grep/Glob/web_search/subagent for repo work.",
 	];
 	if (lock.phase === "post_spawn") {
 		lines.push("- PIMUX HAPPY-PATH DISCIPLINE: this run is notify-first, not poll-first.");
-		lines.push("- Do not poll pimux or use Bash sleep/wait loops; wait for delivered child activity, and treat status/capture/tree/list/open as recovery-only.");
+		lines.push("- Do not poll pimux or use Bash sleep/wait loops; wait for delivered child activity, and treat status/activity/capture/tree/list/open as recovery-only.");
 		lines.push("- Allowed happy-path sequence: spawn -> wait for child report -> send_message once if needed -> wait for closeout -> final status verification.");
 		lines.push(
-			`- Use status/capture/tree/list/open only for explicit live inspection, suspected stall/protocol violation/failure, terminal settlement verification, or the ${CONTROL_PLANE_INACTIVITY_WATCHDOG_LABEL} inactivity watchdog.`,
+			`- Use status/activity/capture/tree/list/open only for explicit live inspection, suspected stall/protocol violation/failure, terminal settlement verification, or the ${CONTROL_PLANE_INACTIVITY_WATCHDOG_LABEL} inactivity watchdog.`,
 		);
 		lines.push("- after terminal settlement, use one final pimux status check before advancing.");
 	}

--- a/packages/pi-ac-workflow/extensions/pimux/docs/commands.md
+++ b/packages/pi-ac-workflow/extensions/pimux/docs/commands.md
@@ -12,6 +12,8 @@ Use `/pimux` with:
 - `tree`
 - `navigate`
 - `status`
+- `activity`
+- `ping`
 - `capture`
 - `send`
 - `kill`
@@ -28,6 +30,8 @@ Use the `pimux` tool with actions:
 - `list`
 - `tree`
 - `status`
+- `activity`
+- `ping_agent`
 - `capture`
 - `send_message`
 - `report_parent`
@@ -67,13 +71,15 @@ Valid `report_parent` kinds:
 
 Parent-side interface delivery should also show parent -> child bridge messages as concise pimux events without triggering an extra turn.
 
-After a terminal `report_parent`, the pimux runtime should finalize the managed session promptly.
+After a terminal `report_parent`, the pimux runtime batches bursty terminal notifications and keeps terminal notification state retryable until the parent delivery queue records delivery.
 
 ## Inspection
 
 - `list` for current-session agents by default
 - `tree` for hierarchy shape
-- `status` for one agent plus settlement state
+- `status` for one agent plus settlement state and pane tail
+- `activity` for deterministic no-capture state (`running_recent_activity`, `running_quiet`, `settled`, `missing_session`, `terminated`, or `protocol_violation`)
+- `ping_agent` / `ping` to send a correlated `status_request`; the child must respond with `progress` if still working or a terminal report if done, blocked, or failed
 - `capture` for pane text
 - `open` to inspect live in iTerm
 - `navigate` to select a node from the current-session hierarchy and act on it

--- a/packages/pi-ac-workflow/extensions/pimux/docs/patterns.md
+++ b/packages/pi-ac-workflow/extensions/pimux/docs/patterns.md
@@ -16,7 +16,7 @@ Use one child when the task is bounded but should stay long-lived or visually in
 4. let the planner return the execution plan
 
 Do not rely on prose inference between steps; hand off file paths or bounded summaries.
-Do not keep the parent blocked with Bash sleep/wait loops or repeated pings while waiting; inspect only at a real handoff, live-watch request, or suspected problem.
+Do not keep the parent blocked with Bash sleep/wait loops or repeated pings while waiting; inspect only at a real handoff, live-watch request, runtime inactivity watchdog notification, or suspected problem.
 
 ## Team / brainstorm pattern
 
@@ -37,7 +37,7 @@ Use pimux as the control-plane runtime for:
 
 Keep wrappers thin:
 - wrapper skill owns prompt and file conventions
-- pimux owns tmux launch, messaging, settlement, visual supervision, and the fail-closed parent control-plane lock
+- pimux owns tmux launch, messaging, settlement, batched terminal parent delivery, visual supervision, inactivity watchdogs, deterministic activity checks, and the fail-closed parent control-plane lock
 - wrapper-triggered parents do not do repo inspection before spawn; they hand off the user objective and let the child read the repo
 - for `mux-ospec`, explicit spec paths pass through unchanged; inline prompts without a path auto-derive/create the next current-branch spec path through the authoritative runtime; only missing user input falls back to `AskUserQuestion`, never parent-side `Read` / `Bash`
 

--- a/packages/pi-ac-workflow/extensions/pimux/docs/protocol.md
+++ b/packages/pi-ac-workflow/extensions/pimux/docs/protocol.md
@@ -71,9 +71,9 @@ Inspect or intervene only when:
 
 For explicit mux-family wrappers, the notify-first default is stricter:
 - child bridge notifications are delivered automatically
-- after spawn, do not call `status`, `capture`, `tree`, `list`, or `open` on the happy path
+- after spawn, do not call `status`, `activity`, `capture`, `tree`, `list`, or `open` on the happy path, except `open` when the user explicitly asks to watch live
 - wait for delivered child activity; after a child progress report arrives, use at most one `send_message` when input is needed
-- treat `status`, `activity`, `capture`, `tree`, `list`, and `open` as recovery-only tools for explicit live inspection, suspected stall/protocol violation/failure, or the inactivity-only watchdog
+- treat `status`, `activity`, `capture`, `tree`, `list`, and `open` as recovery-only tools for suspected stall/protocol violation/failure or the inactivity-only watchdog; `open` is also allowed for explicit user live-inspection requests
 - use `activity` when deterministic bridge/process state is enough and pane capture is unnecessary
 - use `ping_agent` only as an active recovery probe; the child must answer the `status_request` with `progress` if still working or a terminal report if finished
 - after terminal settlement, use one final `pimux status` or `pimux activity` check before advancing

--- a/packages/pi-ac-workflow/extensions/pimux/docs/protocol.md
+++ b/packages/pi-ac-workflow/extensions/pimux/docs/protocol.md
@@ -5,7 +5,7 @@ Package-owned runtime protocol docs for the `pimux` extension command, tool, bri
 ## Messaging model
 
 - FIRST: do not poll pimux and do not use Bash sleep/wait loops; wait for delivered child activity.
-- parent -> child: explicit bridge inbox events via `send_message`
+- parent -> child: explicit bridge inbox events via `send_message` or correlated `status_request` probes from `ping_agent`
 - child -> parent: explicit bridge reports via `report_parent`
 - one hop only: L2 reports to L1, L1 reports to L0
 
@@ -31,6 +31,7 @@ Implications:
 
 After a terminal child report, the pimux runtime should finalize the managed session promptly instead of leaving the child alive in an ambiguous post-closeout state.
 The child should not keep chatting or continue work after emitting a terminal report.
+Terminal settlement notification is durable parent-delivery work: bursty terminal reports may be batched, and a terminal notification remains retryable until the parent delivery queue records delivery metadata for that bridge.
 
 ## Nested orchestrator rule
 
@@ -65,14 +66,17 @@ Inspect or intervene only when:
 - the child emits a bridge report
 - the user asks to inspect live progress
 - a real downstream handoff now depends on settlement
+- the runtime inactivity watchdog reports that a child exceeded the quiet threshold
 - there is concrete evidence of a stall, blocker, or protocol problem
 
 For explicit mux-family wrappers, the notify-first default is stricter:
 - child bridge notifications are delivered automatically
 - after spawn, do not call `status`, `capture`, `tree`, `list`, or `open` on the happy path
 - wait for delivered child activity; after a child progress report arrives, use at most one `send_message` when input is needed
-- treat `status`, `capture`, `tree`, `list`, and `open` as recovery-only tools for explicit live inspection, suspected stall/protocol violation/failure, or the inactivity-only watchdog
-- after terminal settlement, use one final `pimux status` check before advancing
+- treat `status`, `activity`, `capture`, `tree`, `list`, and `open` as recovery-only tools for explicit live inspection, suspected stall/protocol violation/failure, or the inactivity-only watchdog
+- use `activity` when deterministic bridge/process state is enough and pane capture is unnecessary
+- use `ping_agent` only as an active recovery probe; the child must answer the `status_request` with `progress` if still working or a terminal report if finished
+- after terminal settlement, use one final `pimux status` or `pimux activity` check before advancing
 
 Do not poll pimux or use Bash sleep/wait loops; wait for delivered child activity. One targeted `status` / `capture` check at a real recovery decision point is fine. Continuous polling is not.
 

--- a/packages/pi-ac-workflow/extensions/pimux/index.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/index.ts
@@ -89,6 +89,13 @@ import {
 	type PruneMode,
 	type ResolvedStatus,
 } from "./registry.ts";
+import {
+	flushQueuedParentDeliveries,
+	hasDeliveredTerminalNotification,
+	shouldNotifyInactivityWatchdog,
+	shouldSendStatusRequestProbe,
+	type QueuedParentDelivery,
+} from "./parent-delivery.ts";
 import { PIMUX_PARAMS } from "./schema.ts";
 import {
 	DEFAULT_CAPTURE_LINES,
@@ -114,7 +121,6 @@ import {
 	shouldDeliverBridgeEventToParent,
 	shouldTriggerTurnForEvent,
 	shouldTriggerTurnForSettledState,
-	type SettledTerminalState,
 } from "./settlement.ts";
 import {
 	buildSessionName,
@@ -152,18 +158,6 @@ interface ReportParentRequest {
 	summary: string;
 	reportMarkdown?: string;
 	requiresResponse?: boolean;
-}
-
-interface QueuedParentDelivery {
-	key: string;
-	bridgeDir: string;
-	launch: BridgeLaunchFile;
-	content: string;
-	triggerTurn: boolean;
-	eventIds: string[];
-	terminalEventId?: string;
-	settledState?: SettledTerminalState;
-	createdAt: string;
 }
 
 interface ParentBridgeProcessingState {
@@ -645,7 +639,7 @@ async function pingManagedAgent(
 	message?: string,
 ): Promise<{ status: ResolvedStatus; activity: Awaited<ReturnType<typeof resolveAgentActivitySnapshot>>; requestId?: string; event?: BridgeEvent }> {
 	const result = await activityManagedAgent(ctx, target);
-	if (result.activity.bridgeSettlementState !== "running" || result.activity.activityState === "terminated" || result.activity.activityState === "missing_session") {
+	if (!shouldSendStatusRequestProbe(result.activity)) {
 		return result;
 	}
 	const record = result.status.record;
@@ -1364,35 +1358,32 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 
 	const flushParentDeliveryQueue = async (ctx: ExtensionContext): Promise<void> => {
 		parentDeliveryFlushTimer = undefined;
-		if (parentDeliveryQueue.size === 0) return;
-		const deliveries = [...parentDeliveryQueue.values()].sort((left, right) => left.createdAt.localeCompare(right.createdAt) || left.key.localeCompare(right.key));
-		parentDeliveryQueue.clear();
-		const batchId = `pimux-batch-${randomUUID()}`;
-		await updateTerminalNotificationState(deliveries, batchId, "queued");
-		try {
-			pi.sendMessage(
-				{
-					customType: "pimux-report",
-					content: buildParentDeliveryBatchContent(deliveries, batchId),
-					display: true,
-					details: { batchId, deliveries },
-				},
-				deliveries.some((delivery) => delivery.triggerTurn)
-					? { triggerTurn: true, deliverAs: "followUp" }
-					: { triggerTurn: false },
-			);
-			await markParentDeliveriesDelivered(deliveries);
-			await updateTerminalNotificationState(deliveries, batchId, "delivered");
-		} catch (error) {
-			for (const delivery of deliveries) parentDeliveryQueue.set(delivery.key, delivery);
-			if (!parentDeliveryFlushTimer) {
+		await flushQueuedParentDeliveries({
+			queue: parentDeliveryQueue,
+			makeBatchId: () => `pimux-batch-${randomUUID()}`,
+			updateTerminalNotificationState,
+			markParentDeliveriesDelivered,
+			sendParentMessage: (batchId, deliveries) => {
+				pi.sendMessage(
+					{
+						customType: "pimux-report",
+						content: buildParentDeliveryBatchContent(deliveries, batchId),
+						display: true,
+						details: { batchId, deliveries },
+					},
+					deliveries.some((delivery) => delivery.triggerTurn)
+						? { triggerTurn: true, deliverAs: "followUp" }
+						: { triggerTurn: false },
+				);
+			},
+			scheduleRetry: () => {
+				if (parentDeliveryFlushTimer) return;
 				parentDeliveryFlushTimer = setTimeout(() => {
 					runBackgroundTask(flushParentDeliveryQueue(ctx));
 				}, PARENT_DELIVERY_DEBOUNCE_MS);
 				parentDeliveryFlushTimer.unref?.();
-			}
-			throw error;
-		}
+			},
+		});
 	};
 
 	const enqueueParentDelivery = (delivery: QueuedParentDelivery, ctx: ExtensionContext): void => {
@@ -1471,11 +1462,11 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 				parentState.terminalState === settlement.settledState &&
 				parentState.terminalEventId === settlement.terminalEvent?.eventId &&
 				parentState.protocolViolationReason === settlement.protocolViolationReason;
-			const notificationDelivered =
-				Boolean(parentState.terminalNotificationDeliveredAt) &&
-				parentState.terminalState === settlement.settledState &&
-				parentState.terminalEventId === settlement.terminalEvent?.eventId &&
-				parentState.protocolViolationReason === settlement.protocolViolationReason;
+			const notificationDelivered = hasDeliveredTerminalNotification(parentState, {
+				terminalState: settlement.settledState,
+				terminalEventId: settlement.terminalEvent?.eventId,
+				protocolViolationReason: settlement.protocolViolationReason,
+			});
 			if (!alreadyObserved) {
 				parentState.terminalState = settlement.settledState;
 				parentState.terminalEventId = settlement.terminalEvent?.eventId;
@@ -1591,10 +1582,15 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 			if (status.bridgeSettlementState && status.bridgeSettlementState !== "running") continue;
 			if (!status.record.bridgeDir || !status.record.launchId) continue;
 			const activity = await resolveAgentActivitySnapshot(status, CONTROL_PLANE_INACTIVITY_WATCHDOG_MS);
-			if (activity.activityState !== "running_quiet" || activity.quietForMs === undefined) continue;
 			const lastActivity = activity.lastBridgeEventAt ?? status.record.lastSeenAt ?? status.record.createdAt;
 			const lastNotifiedAt = watchdogNotifiedAtByAgent.get(status.record.agentId);
-			if (lastNotifiedAt && lastNotifiedAt >= lastActivity && Date.now() - Date.parse(lastNotifiedAt) < CONTROL_PLANE_INACTIVITY_WATCHDOG_MS) {
+			if (!shouldNotifyInactivityWatchdog({
+				activity,
+				lastActivity,
+				lastNotifiedAt,
+				nowMs: Date.now(),
+				thresholdMs: CONTROL_PLANE_INACTIVITY_WATCHDOG_MS,
+			})) {
 				continue;
 			}
 			const launch = await readBridgeLaunch(status.record.bridgeDir);
@@ -1963,7 +1959,6 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 					target = selected?.agentId;
 					if (!target) return;
 				}
-				if (!target) throw new Error("ping requires target");
 				const result = await pingManagedAgent(ctx, target, messageParts.join(" "));
 				const lines = result.requestId
 					? [`Sent status_request ${result.requestId} to ${result.status.record.agentId}.`, "", ...formatAgentActivitySnapshot(result.activity)]

--- a/packages/pi-ac-workflow/extensions/pimux/index.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/index.ts
@@ -1163,6 +1163,14 @@ const NO_POLLING_SPAWN_ECHO = "NO-POLL: do not poll pimux or use Bash sleep/wait
 const PARENT_DELIVERY_DEBOUNCE_MS = 75;
 const BACKGROUND_MONITOR_INTERVAL_MS = 30_000;
 
+function logBackgroundError(error: unknown): void {
+	console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+}
+
+function runBackgroundTask(task: Promise<void>): void {
+	void task.catch(logBackgroundError);
+}
+
 function filterAvailableTools(pi: ExtensionAPI, requestedTools: string[]): string[] {
 	const available = new Set(pi.getAllTools().map((tool) => tool.name));
 	return requestedTools.filter((name, index) => requestedTools.indexOf(name) === index && available.has(name));
@@ -1361,7 +1369,7 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 			for (const delivery of deliveries) parentDeliveryQueue.set(delivery.key, delivery);
 			if (!parentDeliveryFlushTimer) {
 				parentDeliveryFlushTimer = setTimeout(() => {
-					void flushParentDeliveryQueue(ctx).catch((flushError) => console.error(flushError));
+					runBackgroundTask(flushParentDeliveryQueue(ctx));
 				}, PARENT_DELIVERY_DEBOUNCE_MS);
 				parentDeliveryFlushTimer.unref?.();
 			}
@@ -1373,7 +1381,7 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 		parentDeliveryQueue.set(delivery.key, delivery);
 		if (parentDeliveryFlushTimer) return;
 		parentDeliveryFlushTimer = setTimeout(() => {
-			void flushParentDeliveryQueue(ctx).catch((error) => console.error(error));
+			runBackgroundTask(flushParentDeliveryQueue(ctx));
 		}, PARENT_DELIVERY_DEBOUNCE_MS);
 		parentDeliveryFlushTimer.unref?.();
 	};
@@ -1538,7 +1546,7 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 		if (parentBridgeWatchers.has(bridgeDir)) return;
 		await fs.mkdir(getBridgeSignalsDir(bridgeDir), { recursive: true });
 		const watcher = watchFs(getBridgeSignalsDir(bridgeDir), { persistent: false }, () => {
-			void processBridgeDeliveries(bridgeDir, getSessionKey(ctx), ctx);
+			runBackgroundTask(processBridgeDeliveries(bridgeDir, getSessionKey(ctx), ctx));
 		});
 		parentBridgeWatchers.set(bridgeDir, watcher);
 	};
@@ -1609,8 +1617,8 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 	const ensureBackgroundMonitor = (ctx: ExtensionContext): void => {
 		if (backgroundMonitorTimer) return;
 		backgroundMonitorTimer = setInterval(() => {
-			void reconcileParentBridgeWatchers(ctx);
-			void processInactivityWatchdog(ctx);
+			runBackgroundTask(reconcileParentBridgeWatchers(ctx));
+			runBackgroundTask(processInactivityWatchdog(ctx));
 		}, BACKGROUND_MONITOR_INTERVAL_MS);
 		backgroundMonitorTimer.unref?.();
 	};
@@ -1674,7 +1682,7 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 		if (!childBridgeWatcher) {
 			await fs.mkdir(getBridgeSignalsDir(currentEnv.bridgeDir), { recursive: true });
 			childBridgeWatcher = watchFs(getBridgeSignalsDir(currentEnv.bridgeDir), { persistent: false }, () => {
-				void processChildInbox(ctx);
+				runBackgroundTask(processChildInbox(ctx));
 			});
 		}
 		await processChildInbox(ctx);

--- a/packages/pi-ac-workflow/extensions/pimux/index.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/index.ts
@@ -44,6 +44,7 @@ import {
 	buildUnlockedControlPlaneLock,
 	evaluateControlPlaneToolCall,
 	evaluateNoPollingSupervisionToolCall,
+	isExplicitLiveInspectionRequest,
 	normalizeControlPlaneLockState,
 	normalizeNoPollingSupervisionState,
 	parseExplicitControlPlaneTrigger,
@@ -1255,6 +1256,7 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 	const queuedChildInboxEventIds = new Set<string>();
 	let controlPlaneLock: ControlPlaneLockState | undefined;
 	let noPollingSupervision: NoPollingSupervisionState | undefined;
+	let explicitLiveInspectionRequested = false;
 
 	const persistNoPollingSupervision = (nextState: NoPollingSupervisionState): void => {
 		noPollingSupervision = nextState;
@@ -2056,6 +2058,7 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 	};
 
 	pi.on("input", async (event, ctx) => {
+		explicitLiveInspectionRequested = isExplicitLiveInspectionRequest(event.text);
 		if (getCurrentEnv().agentId) {
 			return { action: "continue" as const };
 		}
@@ -2085,10 +2088,11 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 
 	pi.on("tool_call", async (event, ctx) => {
 		const currentLock = getParentControlPlaneLock(ctx, controlPlaneLock);
+		const toolContext = { explicitLiveInspectionRequested };
 		const decision = evaluateControlPlaneToolCall(currentLock, {
 			toolName: event.toolName,
 			input: event.input as Record<string, unknown> | undefined,
-		});
+		}, undefined, toolContext);
 		if (!decision.allow) {
 			return {
 				block: true,
@@ -2098,7 +2102,7 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 		const supervisionDecision = evaluateNoPollingSupervisionToolCall(noPollingSupervision, {
 			toolName: event.toolName,
 			input: event.input as Record<string, unknown> | undefined,
-		});
+		}, undefined, toolContext);
 		if (!supervisionDecision.allow) {
 			return {
 				block: true,
@@ -2277,7 +2281,7 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 			"Default to headless agents unless the user explicitly wants to watch live.",
 			"Use send_message for parent-to-child messaging and report_parent for child-to-parent reporting.",
 			"Use activity for deterministic no-capture state checks; use ping_agent to request a correlated child liveness response.",
-			"Treat status/activity/capture/tree/list/open as recovery-only after spawn; do not inspect routine progress.",
+			"Treat status/activity/capture/tree/list/open as recovery-only after spawn; open is allowed when the user explicitly asks to watch live.",
 			"Use report_parent only from the authoritative direct pimux child session. Local helpers are local-only and must not call pimux or report_parent.",
 			"Success settles only after closeout plus child exit. Progress is non-terminal; question is terminal waiting-on-parent settlement.",
 			"For same-session child questions that must continue, use report_parent(progress, requiresResponse=true), not question.",

--- a/packages/pi-ac-workflow/extensions/pimux/index.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/index.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { promises as fs, watch as watchFs } from "node:fs";
 import type { FSWatcher } from "node:fs";
 import * as path from "node:path";
@@ -36,6 +37,7 @@ import {
 import {
 	CONTROL_PLANE_LOCK_ENTRY_TYPE,
 	NO_POLLING_SUPERVISION_ENTRY_TYPE,
+	CONTROL_PLANE_INACTIVITY_WATCHDOG_MS,
 	buildControlPlaneLock,
 	buildControlPlaneSystemPrompt,
 	buildNoPollingSupervisionForSpawn,
@@ -66,6 +68,7 @@ import {
 	filterStatusesForList,
 	findBlockingDirectChildrenForCloseout,
 	flattenTreeNodes,
+	formatAgentActivitySnapshot,
 	formatAgentDetails,
 	formatAgentSummary,
 	formatPruneCandidate,
@@ -73,6 +76,7 @@ import {
 	readRegistry,
 	readSessionRegistry,
 	rememberSessionBridge,
+	resolveAgentActivitySnapshot,
 	resolvePruneAgeReference,
 	resolveStatuses,
 	resolveTargetFromInput,
@@ -110,6 +114,7 @@ import {
 	shouldDeliverBridgeEventToParent,
 	shouldTriggerTurnForEvent,
 	shouldTriggerTurnForSettledState,
+	type SettledTerminalState,
 } from "./settlement.ts";
 import {
 	buildSessionName,
@@ -149,6 +154,23 @@ interface ReportParentRequest {
 	requiresResponse?: boolean;
 }
 
+interface QueuedParentDelivery {
+	key: string;
+	bridgeDir: string;
+	launch: BridgeLaunchFile;
+	content: string;
+	triggerTurn: boolean;
+	eventIds: string[];
+	terminalEventId?: string;
+	settledState?: SettledTerminalState;
+	createdAt: string;
+}
+
+interface ParentBridgeProcessingState {
+	running: boolean;
+	rerunRequested: boolean;
+}
+
 interface ParsedArgs {
 	flags: Map<string, string | boolean>;
 	positionals: string[];
@@ -163,6 +185,8 @@ function buildUsage(): string {
 		"  /pimux tree [--all] [--include-exited] [--root ID]",
 		"  /pimux navigate [--all] [--include-exited] [--root ID]",
 		"  /pimux status [target|last]",
+		"  /pimux activity [target|last]",
+		"  /pimux ping [target|last] [message]",
 		"  /pimux capture [target|last] [--lines N]",
 		"  /pimux send [target|last] <message>",
 		"  /pimux kill [target|last]",
@@ -574,11 +598,7 @@ async function treeManagedAgents(
 	return { lines: buildTreeLines(nodes, formatOptions), nodes };
 }
 
-async function statusManagedAgent(
-	ctx: ExtensionContext,
-	target: string | undefined,
-	lines = 40,
-): Promise<{ status: ResolvedStatus; capture?: string }> {
+async function resolveManagedAgentStatus(ctx: ExtensionContext, target: string | undefined): Promise<ResolvedStatus> {
 	const stateRoot = getStateRoot(ctx.cwd);
 	const registry = await readRegistry(stateRoot);
 	const currentEnv = getCurrentEnv();
@@ -587,6 +607,15 @@ async function statusManagedAgent(
 	const statuses = await resolveStatuses(stateRoot, registry);
 	const status = statuses.find((entry) => entry.record.agentId === record.agentId);
 	if (!status) throw new Error(`Managed agent not found: ${target ?? "(none)"}`);
+	return status;
+}
+
+async function statusManagedAgent(
+	ctx: ExtensionContext,
+	target: string | undefined,
+	lines = 40,
+): Promise<{ status: ResolvedStatus; capture?: string }> {
+	const status = await resolveManagedAgentStatus(ctx, target);
 	let capture: string | undefined;
 	if (status.hasSession) {
 		capture = await captureTmuxPane(status.record.sessionName, lines).catch(() => undefined);
@@ -602,6 +631,56 @@ async function captureManagedAgent(
 	const result = await statusManagedAgent(ctx, target, lines);
 	if (!result.capture) throw new Error(`No tmux pane capture available for ${target ?? "(current)"}`);
 	return { status: result.status, capture: result.capture };
+}
+
+async function activityManagedAgent(ctx: ExtensionContext, target: string | undefined): Promise<{ status: ResolvedStatus; activity: Awaited<ReturnType<typeof resolveAgentActivitySnapshot>> }> {
+	const status = await resolveManagedAgentStatus(ctx, target);
+	const activity = await resolveAgentActivitySnapshot(status, CONTROL_PLANE_INACTIVITY_WATCHDOG_MS);
+	return { status, activity };
+}
+
+async function pingManagedAgent(
+	ctx: ExtensionContext,
+	target: string | undefined,
+	message?: string,
+): Promise<{ status: ResolvedStatus; activity: Awaited<ReturnType<typeof resolveAgentActivitySnapshot>>; requestId?: string; event?: BridgeEvent }> {
+	const result = await activityManagedAgent(ctx, target);
+	if (result.activity.bridgeSettlementState !== "running" || result.activity.activityState === "terminated" || result.activity.activityState === "missing_session") {
+		return result;
+	}
+	const record = result.status.record;
+	if (!record.bridgeDir || !record.launchId) {
+		throw new Error(`Managed agent ${record.agentId} does not have a bridge inbox.`);
+	}
+	const currentEnv = getCurrentEnv();
+	const requestId = `status-${randomUUID()}`;
+	const summary = `status request ${requestId}`;
+	const payload = [
+		`PIMUX_STATUS_REQUEST ${requestId}`,
+		"Reply promptly via pimux report_parent:",
+		"- reportKind=progress if you are still working; include this request id in the summary.",
+		"- reportKind=closeout if the mission is complete.",
+		"- reportKind=blocker or reportKind=failure if terminally blocked or failed.",
+		message?.trim() ? `Parent note: ${message.trim()}` : undefined,
+	].filter((line): line is string => Boolean(line)).join("\n");
+	const event = await appendBridgeEvent(record.bridgeDir, {
+		launchId: record.launchId,
+		direction: "parent_to_child",
+		type: "status_request",
+		from: { agentId: currentEnv.agentId ?? "human", sessionFile: ctx.sessionManager.getSessionFile() ?? undefined },
+		to: { agentId: record.agentId, sessionName: record.sessionName },
+		summary,
+		message: payload,
+	});
+	await writeBridgeEventSignal(record.bridgeDir, event, true);
+	record.lastMessageAt = nowIso();
+	record.updatedAt = record.lastMessageAt;
+	await updateRegistry(getStateRoot(ctx.cwd), (next) => {
+		const found = next.agents.find((entry) => entry.agentId === record.agentId);
+		if (found) Object.assign(found, record);
+	});
+	await persistAgentManifest(record);
+	return { ...result, requestId, event };
 }
 
 async function openManagedAgent(ctx: ExtensionContext, target: string | undefined): Promise<ManagedAgentRecord> {
@@ -1081,6 +1160,8 @@ function buildToolResult(text: string, details: Record<string, unknown>) {
 
 const CONTROL_PLANE_ACTIVE_TOOLS = ["pimux", "AskUserQuestion", "say"];
 const NO_POLLING_SPAWN_ECHO = "NO-POLL: do not poll pimux or use Bash sleep/wait loops; wait for delivered child activity.";
+const PARENT_DELIVERY_DEBOUNCE_MS = 75;
+const BACKGROUND_MONITOR_INTERVAL_MS = 30_000;
 
 function filterAvailableTools(pi: ExtensionAPI, requestedTools: string[]): string[] {
 	const available = new Set(pi.getAllTools().map((tool) => tool.name));
@@ -1163,7 +1244,11 @@ function getSessionBridgeEntries(ctx: ExtensionContext): SessionBridgeEntry[] {
 export default function pimuxExtension(pi: ExtensionAPI) {
 	const parentBridgeWatchers = new Map<string, FSWatcher>();
 	let childBridgeWatcher: FSWatcher | undefined;
-	const processingParentBridges = new Set<string>();
+	const processingParentBridges = new Map<string, ParentBridgeProcessingState>();
+	const parentDeliveryQueue = new Map<string, QueuedParentDelivery>();
+	const watchdogNotifiedAtByAgent = new Map<string, string>();
+	let parentDeliveryFlushTimer: ReturnType<typeof setTimeout> | undefined;
+	let backgroundMonitorTimer: ReturnType<typeof setInterval> | undefined;
 	let processingChildBridge = false;
 	const queuedChildInboxEventIds = new Set<string>();
 	let controlPlaneLock: ControlPlaneLockState | undefined;
@@ -1215,68 +1300,167 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 		restoreToolSurface(pi, restored.previousActiveTools);
 	};
 
+	const buildParentDeliveryBatchContent = (deliveries: QueuedParentDelivery[], batchId: string): string => {
+		if (deliveries.length === 1) return deliveries[0].content;
+		return [
+			`# pimux reports: ${deliveries.length} updates`,
+			`Batch ID: ${batchId}`,
+			"",
+			...deliveries.flatMap((delivery, index) => [
+				`## ${index + 1}. ${delivery.launch.agentId}`,
+				"",
+				delivery.content,
+				"",
+			]),
+		].join("\n").trimEnd();
+	};
+
+	const updateTerminalNotificationState = async (
+		deliveries: QueuedParentDelivery[],
+		batchId: string,
+		phase: "queued" | "delivered",
+	): Promise<void> => {
+		const terminalDeliveries = deliveries.filter((delivery) => delivery.settledState);
+		for (const delivery of terminalDeliveries) {
+			const parentState = await readBridgeParentState(delivery.bridgeDir).catch(() => ({ deliveredEventIds: [] }));
+			const timestamp = nowIso();
+			parentState.terminalEventId = delivery.terminalEventId;
+			parentState.terminalState = delivery.settledState;
+			parentState.terminalNotificationBatchId = batchId;
+			if (phase === "queued") {
+				parentState.terminalNotificationQueuedAt = timestamp;
+				parentState.terminalNotificationAttemptCount = (parentState.terminalNotificationAttemptCount ?? 0) + 1;
+			} else {
+				parentState.terminalNotificationDeliveredAt = timestamp;
+			}
+			await writeBridgeParentState(delivery.bridgeDir, parentState);
+		}
+	};
+
+	const flushParentDeliveryQueue = async (ctx: ExtensionContext): Promise<void> => {
+		parentDeliveryFlushTimer = undefined;
+		if (parentDeliveryQueue.size === 0) return;
+		const deliveries = [...parentDeliveryQueue.values()].sort((left, right) => left.createdAt.localeCompare(right.createdAt) || left.key.localeCompare(right.key));
+		parentDeliveryQueue.clear();
+		const batchId = `pimux-batch-${randomUUID()}`;
+		await updateTerminalNotificationState(deliveries, batchId, "queued");
+		try {
+			pi.sendMessage(
+				{
+					customType: "pimux-report",
+					content: buildParentDeliveryBatchContent(deliveries, batchId),
+					display: true,
+					details: { batchId, deliveries },
+				},
+				deliveries.some((delivery) => delivery.triggerTurn)
+					? { triggerTurn: true, deliverAs: "followUp" }
+					: { triggerTurn: false },
+			);
+			await updateTerminalNotificationState(deliveries, batchId, "delivered");
+		} catch (error) {
+			for (const delivery of deliveries) parentDeliveryQueue.set(delivery.key, delivery);
+			if (!parentDeliveryFlushTimer) {
+				parentDeliveryFlushTimer = setTimeout(() => {
+					void flushParentDeliveryQueue(ctx).catch((flushError) => console.error(flushError));
+				}, PARENT_DELIVERY_DEBOUNCE_MS);
+				parentDeliveryFlushTimer.unref?.();
+			}
+			throw error;
+		}
+	};
+
+	const enqueueParentDelivery = (delivery: QueuedParentDelivery, ctx: ExtensionContext): void => {
+		parentDeliveryQueue.set(delivery.key, delivery);
+		if (parentDeliveryFlushTimer) return;
+		parentDeliveryFlushTimer = setTimeout(() => {
+			void flushParentDeliveryQueue(ctx).catch((error) => console.error(error));
+		}, PARENT_DELIVERY_DEBOUNCE_MS);
+		parentDeliveryFlushTimer.unref?.();
+	};
+
 	const updateDashboard = async (ctx: ExtensionContext) => {
 		if (!ctx.hasUI) return;
 		const statuses = await listManagedAgents(ctx, { scope: "session", includeExited: false }).catch(() => []);
 		ctx.ui.setWidget(EXTENSION_NAME, dashboardLines(statuses));
 	};
 
-	const processBridgeDeliveries = async (bridgeDir: string, sessionKey: string, ctx: ExtensionContext) => {
-		if (processingParentBridges.has(bridgeDir)) return;
-		processingParentBridges.add(bridgeDir);
-		try {
-			const launch = await readBridgeLaunch(bridgeDir);
-			if (launch.parentSessionKey !== sessionKey) return;
-			let parentState = await readBridgeParentState(bridgeDir);
-			const delivered = new Set(parentState.deliveredEventIds);
-			let changed = false;
-			let events = await readBridgeEvents(bridgeDir);
-			let terminalReportForAutoExit: BridgeEvent | undefined;
-			const currentLock = getParentControlPlaneLock(ctx, controlPlaneLock);
-			const currentSupervision = noPollingSupervision;
-			let nextLock = currentLock;
-			let nextSupervision = currentSupervision;
-			for (const event of events) {
-				if (delivered.has(event.eventId)) continue;
-				if (isTerminalChildReportEvent(event)) {
-					terminalReportForAutoExit = event;
-				}
-				if (event.direction === "child_to_parent" && !isTerminalChildReportEvent(event)) {
-					nextLock = updateControlPlaneLockForChildActivity(nextLock, {
-						agentId: launch.agentId,
-						eventId: event.eventId,
-						timestamp: event.timestamp,
-					});
-					nextSupervision = updateNoPollingSupervisionForChildActivity(nextSupervision, {
-						agentId: launch.agentId,
-						eventId: event.eventId,
-						timestamp: event.timestamp,
-					});
-				}
-				if (shouldDeliverBridgeEventToParent(event)) {
-					const content = await buildParentDeliveryContent(event, launch);
-					pi.sendMessage(
-						{ customType: "pimux-report", content, display: true, details: { launch, event } },
-						shouldTriggerTurnForEvent(event, launch)
-							? { triggerTurn: true, deliverAs: "followUp" }
-							: { triggerTurn: false },
-					);
-				}
+	const processBridgeDeliveriesOnce = async (bridgeDir: string, sessionKey: string, ctx: ExtensionContext) => {
+		const launch = await readBridgeLaunch(bridgeDir);
+		if (launch.parentSessionKey !== sessionKey) return;
+		let parentState = await readBridgeParentState(bridgeDir);
+		const delivered = new Set(parentState.deliveredEventIds);
+		let changed = false;
+		let events = await readBridgeEvents(bridgeDir);
+		let terminalReportForAutoExit: BridgeEvent | undefined;
+		const currentLock = getParentControlPlaneLock(ctx, controlPlaneLock);
+		const currentSupervision = noPollingSupervision;
+		let nextLock = currentLock;
+		let nextSupervision = currentSupervision;
+		for (const event of events) {
+			const terminalReport = isTerminalChildReportEvent(event);
+			if (!terminalReport && delivered.has(event.eventId)) continue;
+			if (terminalReport) {
+				terminalReportForAutoExit = event;
+			}
+			if (event.direction === "child_to_parent" && !terminalReport) {
+				nextLock = updateControlPlaneLockForChildActivity(nextLock, {
+					agentId: launch.agentId,
+					eventId: event.eventId,
+					timestamp: event.timestamp,
+				});
+				nextSupervision = updateNoPollingSupervisionForChildActivity(nextSupervision, {
+					agentId: launch.agentId,
+					eventId: event.eventId,
+					timestamp: event.timestamp,
+				});
+			}
+			if (shouldDeliverBridgeEventToParent(event)) {
+				const content = await buildParentDeliveryContent(event, launch);
+				enqueueParentDelivery(
+					{
+						key: `event:${event.eventId}`,
+						bridgeDir,
+						launch,
+						content,
+						triggerTurn: shouldTriggerTurnForEvent(event, launch),
+						eventIds: [event.eventId],
+						createdAt: event.timestamp,
+					},
+					ctx,
+				);
+				delivered.add(event.eventId);
+				changed = true;
+			} else if (!terminalReport) {
 				delivered.add(event.eventId);
 				changed = true;
 			}
-			if (terminalReportForAutoExit && !events.some((event) => event.direction === "system" && event.type === "exited")) {
-				events = await finalizeManagedAgentAfterTerminalReport(launch, ctx);
-				parentState = await readBridgeParentState(bridgeDir);
-			}
-			const settlement = evaluateBridgeSettlement(events);
-			const alreadyFinalized =
-				Boolean(parentState.terminalFinalizedAt) &&
+		}
+		if (terminalReportForAutoExit && !events.some((event) => event.direction === "system" && event.type === "exited")) {
+			events = await finalizeManagedAgentAfterTerminalReport(launch, ctx);
+			parentState = await readBridgeParentState(bridgeDir);
+		}
+		const settlement = evaluateBridgeSettlement(events);
+		if (settlement.settledState !== "running") {
+			const finalizedAt = parentState.terminalFinalizedAt ?? nowIso();
+			const alreadyObserved =
+				Boolean(parentState.terminalObservedAt) &&
 				parentState.terminalState === settlement.settledState &&
 				parentState.terminalEventId === settlement.terminalEvent?.eventId &&
 				parentState.protocolViolationReason === settlement.protocolViolationReason;
-			if (settlement.settledState !== "running" && !alreadyFinalized) {
-				const finalizedAt = nowIso();
+			const notificationDelivered =
+				Boolean(parentState.terminalNotificationDeliveredAt) &&
+				parentState.terminalState === settlement.settledState &&
+				parentState.terminalEventId === settlement.terminalEvent?.eventId &&
+				parentState.protocolViolationReason === settlement.protocolViolationReason;
+			if (!alreadyObserved) {
+				parentState.terminalState = settlement.settledState;
+				parentState.terminalEventId = settlement.terminalEvent?.eventId;
+				parentState.terminalFinalizedAt = finalizedAt;
+				parentState.terminalObservedAt = finalizedAt;
+				parentState.protocolViolationReason = settlement.protocolViolationReason;
+				changed = true;
+			}
+			if (!notificationDelivered) {
 				let content: string;
 				if (settlement.terminalEvent) {
 					content = await buildParentDeliveryContent(settlement.terminalEvent, launch, {
@@ -1292,16 +1476,20 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 						settlement.protocolViolationReason ?? "Child exited without a valid terminal declaration.",
 					);
 				}
-				pi.sendMessage(
-					{ customType: "pimux-report", content, display: true, details: { launch, settlement, finalizedAt } },
-					shouldTriggerTurnForSettledState(settlement.settledState, launch)
-						? { triggerTurn: true, deliverAs: "followUp" }
-						: { triggerTurn: false },
+				enqueueParentDelivery(
+					{
+						key: `settlement:${bridgeDir}:${settlement.terminalEvent?.eventId ?? settlement.settledState}`,
+						bridgeDir,
+						launch,
+						content,
+						triggerTurn: shouldTriggerTurnForSettledState(settlement.settledState, launch),
+						eventIds: settlement.terminalEvent ? [settlement.terminalEvent.eventId] : [],
+						terminalEventId: settlement.terminalEvent?.eventId,
+						settledState: settlement.settledState,
+						createdAt: finalizedAt,
+					},
+					ctx,
 				);
-				parentState.terminalState = settlement.settledState;
-				parentState.terminalEventId = settlement.terminalEvent?.eventId;
-				parentState.terminalFinalizedAt = finalizedAt;
-				parentState.protocolViolationReason = settlement.protocolViolationReason;
 				nextLock = updateControlPlaneLockForTerminalSettlement(nextLock, {
 					agentId: launch.agentId,
 					eventId: settlement.terminalEvent?.eventId,
@@ -1312,20 +1500,35 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 					eventId: settlement.terminalEvent?.eventId,
 					timestamp: finalizedAt,
 				});
-				changed = true;
 			}
-			if (nextLock && nextLock !== currentLock) {
-				persistControlPlaneLock(nextLock);
-				applyControlPlaneToolSurface(pi);
-			}
-			if (nextSupervision && nextSupervision !== currentSupervision) {
-				persistNoPollingSupervision(nextSupervision);
-			}
-			if (changed) {
-				parentState.deliveredEventIds = Array.from(delivered).slice(-500);
-				await writeBridgeParentState(bridgeDir, parentState);
-			}
-			await updateDashboard(ctx);
+		}
+		if (nextLock && nextLock !== currentLock) {
+			persistControlPlaneLock(nextLock);
+			applyControlPlaneToolSurface(pi);
+		}
+		if (nextSupervision && nextSupervision !== currentSupervision) {
+			persistNoPollingSupervision(nextSupervision);
+		}
+		if (changed) {
+			parentState.deliveredEventIds = Array.from(delivered).slice(-500);
+			await writeBridgeParentState(bridgeDir, parentState);
+		}
+		await updateDashboard(ctx);
+	};
+
+	const processBridgeDeliveries = async (bridgeDir: string, sessionKey: string, ctx: ExtensionContext) => {
+		const existing = processingParentBridges.get(bridgeDir);
+		if (existing?.running) {
+			existing.rerunRequested = true;
+			return;
+		}
+		const state: ParentBridgeProcessingState = { running: true, rerunRequested: false };
+		processingParentBridges.set(bridgeDir, state);
+		try {
+			do {
+				state.rerunRequested = false;
+				await processBridgeDeliveriesOnce(bridgeDir, sessionKey, ctx);
+			} while (state.rerunRequested);
 		} finally {
 			processingParentBridges.delete(bridgeDir);
 		}
@@ -1352,6 +1555,64 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 			watcher.close();
 			parentBridgeWatchers.delete(bridgeDir);
 		}
+		if (desired.size > 0) ensureBackgroundMonitor(ctx);
+		else stopBackgroundMonitor();
+	};
+
+	const processInactivityWatchdog = async (ctx: ExtensionContext): Promise<void> => {
+		const sessionKey = getSessionKey(ctx);
+		const statuses = await listManagedAgents(ctx, { scope: "session", includeExited: true }).catch(() => []);
+		for (const status of statuses) {
+			if (status.record.parentSessionKey !== sessionKey) continue;
+			if (status.bridgeSettlementState && status.bridgeSettlementState !== "running") continue;
+			if (!status.record.bridgeDir || !status.record.launchId) continue;
+			const activity = await resolveAgentActivitySnapshot(status, CONTROL_PLANE_INACTIVITY_WATCHDOG_MS);
+			if (activity.activityState !== "running_quiet" || activity.quietForMs === undefined) continue;
+			const lastActivity = activity.lastBridgeEventAt ?? status.record.lastSeenAt ?? status.record.createdAt;
+			const lastNotifiedAt = watchdogNotifiedAtByAgent.get(status.record.agentId);
+			if (lastNotifiedAt && lastNotifiedAt >= lastActivity && Date.now() - Date.parse(lastNotifiedAt) < CONTROL_PLANE_INACTIVITY_WATCHDOG_MS) {
+				continue;
+			}
+			const launch = await readBridgeLaunch(status.record.bridgeDir);
+			const content = [
+				"# pimux inactivity watchdog",
+				"",
+				`${status.record.agentId} has had no bridge activity for ${Math.round(activity.quietForMs / 60_000)}m.`,
+				"",
+				"Deterministic state:",
+				...formatAgentActivitySnapshot(activity).map((line) => `- ${line}`),
+				"",
+				"Recommended recovery: use pimux activity for a deterministic check, or pimux ping_agent to request a child response.",
+			].join("\n");
+			enqueueParentDelivery(
+				{
+					key: `watchdog:${status.record.agentId}:${lastActivity}`,
+					bridgeDir: status.record.bridgeDir,
+					launch,
+					content,
+					triggerTurn: true,
+					eventIds: [],
+					createdAt: nowIso(),
+				},
+				ctx,
+			);
+			watchdogNotifiedAtByAgent.set(status.record.agentId, nowIso());
+		}
+	};
+
+	const stopBackgroundMonitor = (): void => {
+		if (!backgroundMonitorTimer) return;
+		clearInterval(backgroundMonitorTimer);
+		backgroundMonitorTimer = undefined;
+	};
+
+	const ensureBackgroundMonitor = (ctx: ExtensionContext): void => {
+		if (backgroundMonitorTimer) return;
+		backgroundMonitorTimer = setInterval(() => {
+			void reconcileParentBridgeWatchers(ctx);
+			void processInactivityWatchdog(ctx);
+		}, BACKGROUND_MONITOR_INTERVAL_MS);
+		backgroundMonitorTimer.unref?.();
 	};
 
 	const processChildInbox = async (ctx: ExtensionContext) => {
@@ -1568,7 +1829,7 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 				console.log(buildUsage());
 				return;
 			}
-			const selected = await ctx.ui.select("pimux", ["spawn", "open", "list", "tree", "navigate", "status", "capture", "send", "kill", "prune", "unlock", "smoke-nested"]);
+			const selected = await ctx.ui.select("pimux", ["spawn", "open", "list", "tree", "navigate", "status", "activity", "ping", "capture", "send", "kill", "prune", "unlock", "smoke-nested"]);
 			if (!selected) return;
 			await handleCommand(selected, ctx);
 			return;
@@ -1651,6 +1912,39 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 				const lines = [...formatAgentDetails(result.status)];
 				if (result.capture) lines.push("", "capture:", ...result.capture.trimEnd().split(/\r?\n/).slice(-20));
 				await presentText(ctx, `pimux status: ${result.status.record.agentId}`, lines);
+				return;
+			}
+			case "activity": {
+				let target = parsed.positionals[0];
+				if (!target && ctx.hasUI) {
+					const selected = await chooseAgent(ctx, "pimux activity", {
+						includeExited: true,
+						emptyMessage: "No pimux agents are available to inspect.",
+					});
+					target = selected?.agentId;
+					if (!target) return;
+				}
+				const result = await activityManagedAgent(ctx, target);
+				await presentText(ctx, `pimux activity: ${result.status.record.agentId}`, formatAgentActivitySnapshot(result.activity));
+				return;
+			}
+			case "ping": {
+				let [target, ...messageParts] = parsed.positionals;
+				if (!target && ctx.hasUI) {
+					const selected = await chooseAgent(ctx, "pimux ping", {
+						requireSession: true,
+						includeExited: false,
+						emptyMessage: "No live pimux agents are available to ping.",
+					});
+					target = selected?.agentId;
+					if (!target) return;
+				}
+				if (!target) throw new Error("ping requires target");
+				const result = await pingManagedAgent(ctx, target, messageParts.join(" "));
+				const lines = result.requestId
+					? [`Sent status_request ${result.requestId} to ${result.status.record.agentId}.`, "", ...formatAgentActivitySnapshot(result.activity)]
+					: [`No ping sent; ${result.status.record.agentId} is not running for active probe.`, "", ...formatAgentActivitySnapshot(result.activity)];
+				await presentText(ctx, `pimux ping: ${result.status.record.agentId}`, lines);
 				return;
 			}
 			case "capture": {
@@ -1933,6 +2227,11 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 		parentBridgeWatchers.clear();
 		childBridgeWatcher?.close();
 		childBridgeWatcher = undefined;
+		if (parentDeliveryFlushTimer) {
+			clearTimeout(parentDeliveryFlushTimer);
+			parentDeliveryFlushTimer = undefined;
+		}
+		stopBackgroundMonitor();
 	});
 
 	pi.registerCommand("pimux", {
@@ -1958,7 +2257,8 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 			"Use this tool when the user wants long-lived tmux-backed Pi agents managed from the current session.",
 			"Default to headless agents unless the user explicitly wants to watch live.",
 			"Use send_message for parent-to-child messaging and report_parent for child-to-parent reporting.",
-			"Treat status/capture/tree/list/open as recovery-only after spawn; do not inspect routine progress.",
+			"Use activity for deterministic no-capture state checks; use ping_agent to request a correlated child liveness response.",
+			"Treat status/activity/capture/tree/list/open as recovery-only after spawn; do not inspect routine progress.",
 			"Use report_parent only from the authoritative direct pimux child session. Local helpers are local-only and must not call pimux or report_parent.",
 			"Success settles only after closeout plus child exit. Progress is non-terminal; question is terminal waiting-on-parent settlement.",
 			"For same-session child questions that must continue, use report_parent(progress, requiresResponse=true), not question.",
@@ -2017,6 +2317,17 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 						const lines = [...formatAgentDetails(result.status)];
 						if (result.capture) lines.push("", "capture:", ...result.capture.trimEnd().split(/\r?\n/).slice(-20));
 						return buildToolResult(lines.join("\n"), { action: params.action, status: result.status, capture: result.capture });
+					}
+					case "activity": {
+						const result = await activityManagedAgent(ctx, params.target);
+						return buildToolResult(formatAgentActivitySnapshot(result.activity).join("\n"), { action: params.action, status: result.status, activity: result.activity });
+					}
+					case "ping_agent": {
+						const result = await pingManagedAgent(ctx, params.target, params.message);
+						const text = result.requestId
+							? `Sent status_request ${result.requestId} to ${result.status.record.agentId}.`
+							: `No ping sent; ${result.status.record.agentId} is not running for active probe.`;
+						return buildToolResult(text, { action: params.action, status: result.status, activity: result.activity, requestId: result.requestId, event: result.event });
 					}
 					case "capture": {
 						const result = await captureManagedAgent(ctx, params.target, params.lines ?? DEFAULT_CAPTURE_LINES);

--- a/packages/pi-ac-workflow/extensions/pimux/index.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/index.ts
@@ -1345,6 +1345,23 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 		}
 	};
 
+	const markParentDeliveriesDelivered = async (deliveries: QueuedParentDelivery[]): Promise<void> => {
+		const eventIdsByBridge = new Map<string, string[]>();
+		for (const delivery of deliveries) {
+			if (delivery.eventIds.length === 0) continue;
+			const eventIds = eventIdsByBridge.get(delivery.bridgeDir) ?? [];
+			eventIds.push(...delivery.eventIds);
+			eventIdsByBridge.set(delivery.bridgeDir, eventIds);
+		}
+		for (const [bridgeDir, eventIds] of eventIdsByBridge.entries()) {
+			const parentState = await readBridgeParentState(bridgeDir).catch(() => ({ deliveredEventIds: [] }));
+			const delivered = new Set(parentState.deliveredEventIds);
+			for (const eventId of eventIds) delivered.add(eventId);
+			parentState.deliveredEventIds = [...delivered].slice(-500);
+			await writeBridgeParentState(bridgeDir, parentState);
+		}
+	};
+
 	const flushParentDeliveryQueue = async (ctx: ExtensionContext): Promise<void> => {
 		parentDeliveryFlushTimer = undefined;
 		if (parentDeliveryQueue.size === 0) return;
@@ -1364,6 +1381,7 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 					? { triggerTurn: true, deliverAs: "followUp" }
 					: { triggerTurn: false },
 			);
+			await markParentDeliveriesDelivered(deliveries);
 			await updateTerminalNotificationState(deliveries, batchId, "delivered");
 		} catch (error) {
 			for (const delivery of deliveries) parentDeliveryQueue.set(delivery.key, delivery);
@@ -1436,8 +1454,6 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 					},
 					ctx,
 				);
-				delivered.add(event.eventId);
-				changed = true;
 			} else if (!terminalReport) {
 				delivered.add(event.eventId);
 				changed = true;

--- a/packages/pi-ac-workflow/extensions/pimux/parent-delivery.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/parent-delivery.ts
@@ -81,10 +81,10 @@ export async function flushQueuedParentDeliveries<TDelivery extends QueuedParent
 ): Promise<ParentDeliveryFlushResult<TDelivery>> {
 	if (options.queue.size === 0) return { deliveries: [], sent: false };
 	const deliveries = [...options.queue.values()].sort((left, right) => left.createdAt.localeCompare(right.createdAt) || left.key.localeCompare(right.key));
-	options.queue.clear();
 	const batchId = options.makeBatchId();
-	await options.updateTerminalNotificationState(deliveries, batchId, "queued");
+	options.queue.clear();
 	try {
+		await options.updateTerminalNotificationState(deliveries, batchId, "queued");
 		options.sendParentMessage(batchId, deliveries);
 		await options.markParentDeliveriesDelivered(deliveries);
 		await options.updateTerminalNotificationState(deliveries, batchId, "delivered");

--- a/packages/pi-ac-workflow/extensions/pimux/parent-delivery.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/parent-delivery.ts
@@ -1,0 +1,98 @@
+import type { BridgeLaunchFile } from "./bridge.ts";
+import type { AgentActivitySnapshot } from "./registry.ts";
+import type { SettledTerminalState } from "./settlement.ts";
+
+export interface QueuedParentDelivery {
+	key: string;
+	bridgeDir: string;
+	launch: BridgeLaunchFile;
+	content: string;
+	triggerTurn: boolean;
+	eventIds: string[];
+	terminalEventId?: string;
+	settledState?: SettledTerminalState;
+	createdAt: string;
+}
+
+export interface TerminalNotificationState {
+	terminalNotificationDeliveredAt?: string;
+	terminalState?: SettledTerminalState;
+	terminalEventId?: string;
+	protocolViolationReason?: string;
+}
+
+export interface TerminalNotificationIdentity {
+	terminalState: SettledTerminalState;
+	terminalEventId?: string;
+	protocolViolationReason?: string;
+}
+
+export interface InactivityWatchdogDecisionInput {
+	activity: Pick<AgentActivitySnapshot, "activityState" | "quietForMs">;
+	lastActivity: string;
+	lastNotifiedAt?: string;
+	nowMs: number;
+	thresholdMs: number;
+}
+
+export interface ParentDeliveryFlushOptions<TDelivery extends QueuedParentDelivery> {
+	queue: Map<string, TDelivery>;
+	makeBatchId: () => string;
+	updateTerminalNotificationState: (deliveries: TDelivery[], batchId: string, phase: "queued" | "delivered") => Promise<void>;
+	sendParentMessage: (batchId: string, deliveries: TDelivery[]) => void;
+	markParentDeliveriesDelivered: (deliveries: TDelivery[]) => Promise<void>;
+	scheduleRetry: () => void;
+}
+
+export interface ParentDeliveryFlushResult<TDelivery extends QueuedParentDelivery> {
+	batchId?: string;
+	deliveries: TDelivery[];
+	sent: boolean;
+}
+
+export function shouldSendStatusRequestProbe(
+	activity: Pick<AgentActivitySnapshot, "bridgeSettlementState" | "activityState">,
+): boolean {
+	return activity.bridgeSettlementState === "running"
+		&& activity.activityState !== "terminated"
+		&& activity.activityState !== "missing_session";
+}
+
+export function hasDeliveredTerminalNotification(
+	parentState: TerminalNotificationState,
+	identity: TerminalNotificationIdentity,
+): boolean {
+	return Boolean(parentState.terminalNotificationDeliveredAt)
+		&& parentState.terminalState === identity.terminalState
+		&& parentState.terminalEventId === identity.terminalEventId
+		&& parentState.protocolViolationReason === identity.protocolViolationReason;
+}
+
+export function shouldNotifyInactivityWatchdog(input: InactivityWatchdogDecisionInput): boolean {
+	if (input.activity.activityState !== "running_quiet" || input.activity.quietForMs === undefined) return false;
+	if (!input.lastNotifiedAt) return true;
+	const lastNotifiedMs = Date.parse(input.lastNotifiedAt);
+	if (!Number.isFinite(lastNotifiedMs)) return true;
+	return !(input.lastNotifiedAt >= input.lastActivity && input.nowMs - lastNotifiedMs < input.thresholdMs);
+}
+
+export async function flushQueuedParentDeliveries<TDelivery extends QueuedParentDelivery>(
+	options: ParentDeliveryFlushOptions<TDelivery>,
+): Promise<ParentDeliveryFlushResult<TDelivery>> {
+	if (options.queue.size === 0) return { deliveries: [], sent: false };
+	const deliveries = [...options.queue.values()].sort((left, right) => left.createdAt.localeCompare(right.createdAt) || left.key.localeCompare(right.key));
+	options.queue.clear();
+	const batchId = options.makeBatchId();
+	await options.updateTerminalNotificationState(deliveries, batchId, "queued");
+	try {
+		options.sendParentMessage(batchId, deliveries);
+		await options.markParentDeliveriesDelivered(deliveries);
+		await options.updateTerminalNotificationState(deliveries, batchId, "delivered");
+		return { batchId, deliveries, sent: true };
+	} catch (error) {
+		for (const delivery of deliveries) options.queue.set(delivery.key, delivery);
+		options.scheduleRetry();
+		throw error;
+	}
+}
+

--- a/packages/pi-ac-workflow/extensions/pimux/registry.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/registry.ts
@@ -17,7 +17,7 @@ import {
 	truncate,
 	type NotificationMode,
 } from "./paths.ts";
-import { evaluateBridgeSettlement, isSettledTerminalState, type BridgeSettlementState } from "./settlement.ts";
+import { evaluateBridgeSettlement, isSettledTerminalState, isTerminalChildReportEvent, type BridgeSettlementState } from "./settlement.ts";
 import type { ManagedVisualRef } from "./tmux.ts";
 import { tmuxHasSession } from "./tmux.ts";
 
@@ -70,6 +70,29 @@ export interface SessionRegistryFile {
 	updatedAt: string;
 	rootAgentIds: string[];
 	bridgeDirs: string[];
+}
+
+export type AgentActivityState =
+	| "settled"
+	| "running_recent_activity"
+	| "running_quiet"
+	| "missing_session"
+	| "terminated"
+	| "protocol_violation";
+
+export interface AgentActivitySnapshot {
+	agentId: string;
+	effectiveStatus: AgentStatus;
+	bridgeSettlementState: BridgeSettlementState;
+	hasSession: boolean;
+	lastBridgeEventAt?: string;
+	lastBridgeEventType?: string;
+	lastBridgeEventSummary?: string;
+	lastChildReportAt?: string;
+	lastParentMessageAt?: string;
+	lastTerminalEventAt?: string;
+	quietForMs?: number;
+	activityState: AgentActivityState;
 }
 
 export interface ResolvedStatus {
@@ -207,6 +230,93 @@ function formatRecentBridgeEvent(event: BridgeEvent): string {
 
 function formatRecentBridgeEvents(events: BridgeEvent[], limit = 5): string[] {
 	return events.slice(-limit).map(formatRecentBridgeEvent);
+}
+
+function sortBridgeEvents(events: BridgeEvent[]): BridgeEvent[] {
+	return [...events].sort((left, right) => left.timestamp.localeCompare(right.timestamp) || left.eventId.localeCompare(right.eventId));
+}
+
+function latestBridgeEvent(events: BridgeEvent[], predicate: (event: BridgeEvent) => boolean): BridgeEvent | undefined {
+	return sortBridgeEvents(events).filter(predicate).at(-1);
+}
+
+function parseIsoMs(value: string | undefined): number | undefined {
+	if (!value) return undefined;
+	const parsed = Date.parse(value);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function resolveActivityState(
+	status: ResolvedStatus,
+	bridgeSettlementState: BridgeSettlementState,
+	quietForMs: number | undefined,
+	quietThresholdMs: number,
+): AgentActivityState {
+	if (bridgeSettlementState === "protocol_violation") return "protocol_violation";
+	if (status.record.status === "terminated" || status.effectiveStatus === "terminated") return "terminated";
+	if (bridgeSettlementState !== "running") return "settled";
+	if (!status.hasSession || status.effectiveStatus === "missing") return "missing_session";
+	if (quietForMs !== undefined && quietForMs >= quietThresholdMs) return "running_quiet";
+	return "running_recent_activity";
+}
+
+export function buildAgentActivitySnapshot(
+	status: ResolvedStatus,
+	events: BridgeEvent[],
+	options: { nowMs?: number; quietThresholdMs?: number } = {},
+): AgentActivitySnapshot {
+	const orderedEvents = sortBridgeEvents(events);
+	const settlement = evaluateBridgeSettlement(orderedEvents);
+	const bridgeSettlementState = settlement.settledState !== "running"
+		? settlement.settledState
+		: status.bridgeSettlementState ?? "running";
+	const lastEvent = orderedEvents.at(-1);
+	const lastChildReport = latestBridgeEvent(orderedEvents, (event) => event.direction === "child_to_parent");
+	const lastParentMessage = latestBridgeEvent(orderedEvents, (event) => event.direction === "parent_to_child");
+	const lastTerminalEvent = latestBridgeEvent(orderedEvents, isTerminalChildReportEvent);
+	const nowMs = options.nowMs ?? Date.now();
+	const lastActivityMs = parseIsoMs(lastEvent?.timestamp) ?? parseIsoMs(status.record.lastSeenAt) ?? parseIsoMs(status.record.updatedAt);
+	const quietForMs = lastActivityMs === undefined ? undefined : Math.max(0, nowMs - lastActivityMs);
+	const quietThresholdMs = options.quietThresholdMs ?? 10 * 60_000;
+	return {
+		agentId: status.record.agentId,
+		effectiveStatus: status.effectiveStatus,
+		bridgeSettlementState,
+		hasSession: status.hasSession,
+		lastBridgeEventAt: lastEvent?.timestamp,
+		lastBridgeEventType: lastEvent?.type,
+		lastBridgeEventSummary: lastEvent ? truncate(lastEvent.summary ?? lastEvent.message ?? lastEvent.type, 160) : undefined,
+		lastChildReportAt: lastChildReport?.timestamp,
+		lastParentMessageAt: lastParentMessage?.timestamp,
+		lastTerminalEventAt: lastTerminalEvent?.timestamp,
+		quietForMs,
+		activityState: resolveActivityState(status, bridgeSettlementState, quietForMs, quietThresholdMs),
+	};
+}
+
+export async function resolveAgentActivitySnapshot(
+	status: ResolvedStatus,
+	quietThresholdMs = 10 * 60_000,
+): Promise<AgentActivitySnapshot> {
+	const events = status.record.bridgeDir ? await readBridgeEvents(status.record.bridgeDir).catch(() => []) : [];
+	return buildAgentActivitySnapshot(status, events, { quietThresholdMs });
+}
+
+export function formatAgentActivitySnapshot(snapshot: AgentActivitySnapshot): string[] {
+	return [
+		`agentId: ${snapshot.agentId}`,
+		`activityState: ${snapshot.activityState}`,
+		`effectiveStatus: ${snapshot.effectiveStatus}`,
+		`bridgeSettlementState: ${snapshot.bridgeSettlementState}`,
+		`hasSession: ${snapshot.hasSession ? "true" : "false"}`,
+		snapshot.quietForMs !== undefined ? `quietForMs: ${snapshot.quietForMs}` : undefined,
+		snapshot.lastBridgeEventAt ? `lastBridgeEventAt: ${snapshot.lastBridgeEventAt}` : undefined,
+		snapshot.lastBridgeEventType ? `lastBridgeEventType: ${snapshot.lastBridgeEventType}` : undefined,
+		snapshot.lastBridgeEventSummary ? `lastBridgeEventSummary: ${snapshot.lastBridgeEventSummary}` : undefined,
+		snapshot.lastChildReportAt ? `lastChildReportAt: ${snapshot.lastChildReportAt}` : undefined,
+		snapshot.lastParentMessageAt ? `lastParentMessageAt: ${snapshot.lastParentMessageAt}` : undefined,
+		snapshot.lastTerminalEventAt ? `lastTerminalEventAt: ${snapshot.lastTerminalEventAt}` : undefined,
+	].filter((line): line is string => Boolean(line));
 }
 
 async function readJsonFile<T>(filePath: string, fallback: T): Promise<T> {

--- a/packages/pi-ac-workflow/extensions/pimux/render.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/render.ts
@@ -92,5 +92,16 @@ export function buildProtocolViolationDeliveryContent(
 }
 
 export function buildChildMessageContent(event: BridgeEvent): string {
+	if (event.type === "status_request") {
+		const message = event.message?.trim() || event.summary?.trim() || "Status requested.";
+		return [
+			message,
+			"",
+			"pimux status_request response contract:",
+			"- If still working, call pimux report_parent with reportKind=progress and include the request id in the summary.",
+			"- If the work is complete, call pimux report_parent with reportKind=closeout.",
+			"- If terminally blocked or failed, call report_parent with reportKind=blocker or reportKind=failure.",
+		].join("\n");
+	}
 	return event.message?.trim() || event.summary?.trim() || "";
 }

--- a/packages/pi-ac-workflow/extensions/pimux/schema.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/schema.ts
@@ -2,7 +2,7 @@ import { StringEnum } from "@mariozechner/pi-ai";
 import { Type } from "@sinclair/typebox";
 
 export const PIMUX_PARAMS = Type.Object({
-	action: StringEnum(["spawn", "open", "list", "tree", "status", "capture", "send_message", "report_parent", "kill", "prune"] as const),
+	action: StringEnum(["spawn", "open", "list", "tree", "status", "activity", "ping_agent", "capture", "send_message", "report_parent", "kill", "prune"] as const),
 	target: Type.Optional(Type.String({ description: "Target agent ID, session name, or 'last'" })),
 	agentId: Type.Optional(Type.String({ description: "Preferred agent ID when spawning" })),
 	cwd: Type.Optional(Type.String({ description: "Working directory for a spawned agent" })),

--- a/packages/pi-ac-workflow/extensions/pimux/settlement.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/settlement.ts
@@ -5,6 +5,7 @@ export type BridgeEventType =
 	| "instruction"
 	| "answer"
 	| "clarification"
+	| "status_request"
 	| "progress"
 	| "question"
 	| "blocker"

--- a/tests/test_pimux_control_plane.py
+++ b/tests/test_pimux_control_plane.py
@@ -560,7 +560,7 @@ def test_successful_spawn_transitions_lock_to_post_spawn_supervision() -> None:
     )
     assert blocked_status == {
         "allow": False,
-        "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the 10m inactivity watchdog.",
+        "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the 10m inactivity watchdog.",
     }
 
     blocked_read = run_runtime(
@@ -589,7 +589,7 @@ def test_post_spawn_blocks_happy_path_verification_checks_until_watchdog() -> No
     )
     assert blocked_status == {
         "allow": False,
-        "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the 10m inactivity watchdog.",
+        "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the 10m inactivity watchdog.",
     }
 
     watchdog_status = run_runtime(
@@ -618,7 +618,7 @@ def test_capture_and_open_are_recovery_only_after_spawn() -> None:
         )
         assert blocked == {
             "allow": False,
-            "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the 10m inactivity watchdog.",
+            "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the 10m inactivity watchdog.",
         }
 
 
@@ -668,7 +668,7 @@ def test_child_activity_rearms_one_recovery_message_not_polling_tools() -> None:
     )
     assert blocked_status == {
         "allow": False,
-        "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the 10m inactivity watchdog.",
+        "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the 10m inactivity watchdog.",
     }
 
     allowed_message = run_runtime(
@@ -778,7 +778,7 @@ def test_terminal_settlement_rearms_one_final_status_only() -> None:
     )
     assert blocked_second_status == {
         "allow": False,
-        "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the 10m inactivity watchdog.",
+        "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the 10m inactivity watchdog.",
     }
 
 
@@ -824,7 +824,7 @@ def test_inactivity_watchdog_allows_one_follow_up_check_without_restarting_polli
     )
     assert blocked_again == {
         "allow": False,
-        "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the 10m inactivity watchdog.",
+        "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the 10m inactivity watchdog.",
     }
 
 
@@ -899,7 +899,7 @@ def test_no_polling_supervision_blocks_routine_pimux_inspection_after_spawn() ->
     )
     assert blocked_status == {
         "allow": False,
-        "reason": "pimux no-polling supervision is active. Do not poll pimux; wait for delivered child activity. status/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the 10m inactivity watchdog.",
+        "reason": "pimux no-polling supervision is active. Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the 10m inactivity watchdog.",
     }
 
     allowed_watchdog_status = run_runtime(

--- a/tests/test_pimux_control_plane.py
+++ b/tests/test_pimux_control_plane.py
@@ -45,7 +45,7 @@ if (payload.action === "build_lock") {
 }
 
 if (payload.action === "evaluate") {
-  writeJson(runtime.evaluateControlPlaneToolCall(payload.lock, payload.event, payload.now));
+  writeJson(runtime.evaluateControlPlaneToolCall(payload.lock, payload.event, payload.now, payload.context));
   process.exit(0);
 }
 
@@ -70,7 +70,7 @@ if (payload.action === "build_no_polling_supervision") {
 }
 
 if (payload.action === "evaluate_no_polling_supervision") {
-  writeJson(runtime.evaluateNoPollingSupervisionToolCall(payload.supervision, payload.event, payload.now));
+  writeJson(runtime.evaluateNoPollingSupervisionToolCall(payload.supervision, payload.event, payload.now, payload.context));
   process.exit(0);
 }
 
@@ -81,6 +81,11 @@ if (payload.action === "no_polling_tool_result") {
 
 if (payload.action === "no_polling_terminal_settlement") {
   writeJson(runtime.updateNoPollingSupervisionForTerminalSettlement(payload.supervision, payload.event, payload.now));
+  process.exit(0);
+}
+
+if (payload.action === "is_explicit_live_inspection") {
+  writeJson(runtime.isExplicitLiveInspectionRequest(payload.text));
   process.exit(0);
 }
 
@@ -560,7 +565,7 @@ def test_successful_spawn_transitions_lock_to_post_spawn_supervision() -> None:
     )
     assert blocked_status == {
         "allow": False,
-        "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the 10m inactivity watchdog.",
+        "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only; open is also allowed when the user explicitly asks to watch live. Other check actions are allowed only after terminal settlement or the 10m inactivity watchdog.",
     }
 
     blocked_read = run_runtime(
@@ -589,7 +594,7 @@ def test_post_spawn_blocks_happy_path_verification_checks_until_watchdog() -> No
     )
     assert blocked_status == {
         "allow": False,
-        "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the 10m inactivity watchdog.",
+        "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only; open is also allowed when the user explicitly asks to watch live. Other check actions are allowed only after terminal settlement or the 10m inactivity watchdog.",
     }
 
     watchdog_status = run_runtime(
@@ -618,8 +623,47 @@ def test_capture_and_open_are_recovery_only_after_spawn() -> None:
         )
         assert blocked == {
             "allow": False,
-            "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the 10m inactivity watchdog.",
+            "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only; open is also allowed when the user explicitly asks to watch live. Other check actions are allowed only after terminal settlement or the 10m inactivity watchdog.",
         }
+
+
+def test_explicit_live_inspection_allows_open_but_not_polling_checks_after_spawn() -> None:
+    """A user request to watch live should allow open only, not status/capture polling."""
+    post_spawn = spawn_post_lock()
+    context = {"explicitLiveInspectionRequested": True}
+    allowed_open = run_runtime(
+        {
+            "action": "evaluate",
+            "lock": post_spawn,
+            "event": {"toolName": "pimux", "input": {"action": "open", "target": "mux-ospec-stage-001"}},
+            "now": "2026-04-17T10:01:00Z",
+            "context": context,
+        }
+    )
+    assert allowed_open == {"allow": True}
+
+    for action in ("status", "capture"):
+        blocked = run_runtime(
+            {
+                "action": "evaluate",
+                "lock": post_spawn,
+                "event": {"toolName": "pimux", "input": {"action": action, "target": "mux-ospec-stage-001"}},
+                "now": "2026-04-17T10:01:00Z",
+                "context": context,
+            }
+        )
+        assert blocked["allow"] is False
+
+
+def test_explicit_live_inspection_detection_is_conservative() -> None:
+    """Live visual inspection intent should require both an open/show verb and a live/tab terminal noun."""
+    assert run_runtime({"action": "is_explicit_live_inspection", "text": "open both live in tabs"}) is True
+    assert run_runtime({"action": "is_explicit_live_inspection", "text": "show me the live agents"}) is True
+    assert run_runtime({"action": "is_explicit_live_inspection", "text": "watch live"}) is True
+    assert run_runtime({"action": "is_explicit_live_inspection", "text": "open in tmux tabs"}) is True
+    assert run_runtime({"action": "is_explicit_live_inspection", "text": "how are they doing?"}) is False
+    assert run_runtime({"action": "is_explicit_live_inspection", "text": "check status"}) is False
+    assert run_runtime({"action": "is_explicit_live_inspection", "text": "any update?"}) is False
 
 
 
@@ -668,7 +712,7 @@ def test_child_activity_rearms_one_recovery_message_not_polling_tools() -> None:
     )
     assert blocked_status == {
         "allow": False,
-        "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the 10m inactivity watchdog.",
+        "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only; open is also allowed when the user explicitly asks to watch live. Other check actions are allowed only after terminal settlement or the 10m inactivity watchdog.",
     }
 
     allowed_message = run_runtime(
@@ -795,7 +839,7 @@ def test_terminal_settlement_rearms_one_final_status_or_activity_only() -> None:
     )
     assert blocked_second_status == {
         "allow": False,
-        "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the 10m inactivity watchdog.",
+        "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only; open is also allowed when the user explicitly asks to watch live. Other check actions are allowed only after terminal settlement or the 10m inactivity watchdog.",
     }
 
 
@@ -841,7 +885,7 @@ def test_inactivity_watchdog_allows_one_follow_up_check_without_restarting_polli
     )
     assert blocked_again == {
         "allow": False,
-        "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the 10m inactivity watchdog.",
+        "reason": "Explicit mux-ospec parent is control-plane locked. Notify-first pacing is active. Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only; open is also allowed when the user explicitly asks to watch live. Other check actions are allowed only after terminal settlement or the 10m inactivity watchdog.",
     }
 
 
@@ -916,7 +960,7 @@ def test_no_polling_supervision_blocks_routine_pimux_inspection_after_spawn() ->
     )
     assert blocked_status == {
         "allow": False,
-        "reason": "pimux no-polling supervision is active. Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only and allowed only after terminal settlement or the 10m inactivity watchdog.",
+        "reason": "pimux no-polling supervision is active. Do not poll pimux; wait for delivered child activity. status/activity/capture/tree/list/open are recovery-only; open is also allowed when the user explicitly asks to watch live. Other check actions are allowed only after terminal settlement or the 10m inactivity watchdog.",
     }
 
     allowed_watchdog_status = run_runtime(
@@ -928,6 +972,34 @@ def test_no_polling_supervision_blocks_routine_pimux_inspection_after_spawn() ->
         }
     )
     assert allowed_watchdog_status == {"allow": True}
+
+
+def test_no_polling_supervision_allows_explicit_live_open_but_not_polling_checks() -> None:
+    """Generic no-polling supervision should honor explicit live open without allowing polling."""
+    supervision = no_polling_supervision()
+    context = {"explicitLiveInspectionRequested": True}
+    allowed_open = run_runtime(
+        {
+            "action": "evaluate_no_polling_supervision",
+            "supervision": supervision,
+            "event": {"toolName": "pimux", "input": {"action": "open", "target": "pimux-worker-001"}},
+            "now": "2026-04-17T10:01:00Z",
+            "context": context,
+        }
+    )
+    assert allowed_open == {"allow": True}
+
+    for action in ("status", "capture"):
+        blocked = run_runtime(
+            {
+                "action": "evaluate_no_polling_supervision",
+                "supervision": supervision,
+                "event": {"toolName": "pimux", "input": {"action": action, "target": "pimux-worker-001"}},
+                "now": "2026-04-17T10:01:00Z",
+                "context": context,
+            }
+        )
+        assert blocked["allow"] is False
 
 
 def test_no_polling_supervision_blocks_bash_sleep_wait_loops_but_allows_normal_commands() -> None:

--- a/tests/test_pimux_control_plane.py
+++ b/tests/test_pimux_control_plane.py
@@ -710,8 +710,8 @@ def test_child_activity_rearms_one_recovery_message_not_polling_tools() -> None:
 
 
 
-def test_terminal_settlement_rearms_one_final_status_only() -> None:
-    """Terminal settlement should allow one final status verification, not more capture or nudges."""
+def test_terminal_settlement_rearms_one_final_status_or_activity_only() -> None:
+    """Terminal settlement should allow one final status/activity verification, not capture or nudges."""
     post_spawn = spawn_post_lock()
     settled = run_runtime(
         {
@@ -731,7 +731,15 @@ def test_terminal_settlement_rearms_one_final_status_only() -> None:
             "event": {"toolName": "pimux", "input": {"action": "status", "target": "mux-ospec-stage-001"}},
         }
     )
+    allowed_activity = run_runtime(
+        {
+            "action": "evaluate",
+            "lock": settled,
+            "event": {"toolName": "pimux", "input": {"action": "activity", "target": "mux-ospec-stage-001"}},
+        }
+    )
     assert allowed_status == {"allow": True}
+    assert allowed_activity == {"allow": True}
 
     blocked_capture = run_runtime(
         {
@@ -742,7 +750,7 @@ def test_terminal_settlement_rearms_one_final_status_only() -> None:
     )
     assert blocked_capture == {
         "allow": False,
-        "reason": "Explicit mux-ospec parent is control-plane locked. Terminal settlement is ready. Use one final pimux status check, then stop supervising this child.",
+        "reason": "Explicit mux-ospec parent is control-plane locked. Terminal settlement is ready. Use one final pimux status or activity check, then stop supervising this child.",
     }
 
     blocked_message = run_runtime(
@@ -757,7 +765,7 @@ def test_terminal_settlement_rearms_one_final_status_only() -> None:
     )
     assert blocked_message == {
         "allow": False,
-        "reason": "Explicit mux-ospec parent is control-plane locked. Terminal settlement is ready. Use one final pimux status check, then stop supervising this child.",
+        "reason": "Explicit mux-ospec parent is control-plane locked. Terminal settlement is ready. Use one final pimux status or activity check, then stop supervising this child.",
     }
 
     after_final_status = run_runtime(
@@ -768,6 +776,15 @@ def test_terminal_settlement_rearms_one_final_status_only() -> None:
             "now": "2026-04-17T10:03:05Z",
         }
     )
+    after_final_activity = run_runtime(
+        {
+            "action": "update_tool_result",
+            "lock": settled,
+            "event": {"toolName": "pimux", "details": {"action": "activity"}, "isError": False},
+            "now": "2026-04-17T10:03:05Z",
+        }
+    )
+    assert after_final_activity["settlementVerificationPending"] is False
     blocked_second_status = run_runtime(
         {
             "action": "evaluate",
@@ -940,8 +957,8 @@ def test_no_polling_supervision_blocks_bash_sleep_wait_loops_but_allows_normal_c
     assert allowed_git == {"allow": True}
 
 
-def test_no_polling_supervision_allows_one_final_status_after_terminal_settlement() -> None:
-    """Terminal settlement should reopen exactly one final status check for verification."""
+def test_no_polling_supervision_allows_one_final_status_or_activity_after_terminal_settlement() -> None:
+    """Terminal settlement should reopen exactly one final status/activity check for verification."""
     supervision = no_polling_supervision()
     settled = run_runtime(
         {
@@ -961,7 +978,15 @@ def test_no_polling_supervision_allows_one_final_status_after_terminal_settlemen
             "event": {"toolName": "pimux", "input": {"action": "status", "target": "pimux-worker-001"}},
         }
     )
+    allowed_activity = run_runtime(
+        {
+            "action": "evaluate_no_polling_supervision",
+            "supervision": settled,
+            "event": {"toolName": "pimux", "input": {"action": "activity", "target": "pimux-worker-001"}},
+        }
+    )
     assert allowed_status == {"allow": True}
+    assert allowed_activity == {"allow": True}
 
     after_status = run_runtime(
         {
@@ -971,7 +996,16 @@ def test_no_polling_supervision_allows_one_final_status_after_terminal_settlemen
             "now": "2026-04-17T10:03:05Z",
         }
     )
+    after_activity = run_runtime(
+        {
+            "action": "no_polling_tool_result",
+            "supervision": settled,
+            "event": {"toolName": "pimux", "details": {"action": "activity"}, "isError": False},
+            "now": "2026-04-17T10:03:05Z",
+        }
+    )
     assert after_status["active"] is False
+    assert after_activity["active"] is False
     allowed_after_supervision = run_runtime(
         {
             "action": "evaluate_no_polling_supervision",

--- a/tests/test_pimux_parent_delivery_behavior.py
+++ b/tests/test_pimux_parent_delivery_behavior.py
@@ -28,6 +28,7 @@ if (payload.action === "flush") {
       makeBatchId: () => "batch-1",
       updateTerminalNotificationState: async (deliveries, batchId, phase) => {
         calls.push({ type: "terminal", phase, batchId, keys: deliveries.map((delivery) => delivery.key) });
+        if (payload.failQueuedState && phase === "queued") throw new Error("queued state failed");
       },
       sendParentMessage: (batchId, deliveries) => {
         calls.push({ type: "send", batchId, keys: deliveries.map((delivery) => delivery.key) });
@@ -117,6 +118,23 @@ def test_flush_requeues_deliveries_when_send_fails() -> None:
     assert set(result["queueKeys"]) == {"a", "b"}
     assert [call["type"] for call in result["calls"]] == ["terminal", "send", "retry"]
     assert not any(call["type"] == "mark" for call in result["calls"])
+
+
+def test_flush_requeues_deliveries_when_queued_state_persistence_fails() -> None:
+    """A failed queued-state write should restore deliveries and schedule retry before send."""
+    result = run_runtime(
+        {
+            "action": "flush",
+            "deliveries": [delivery("b"), delivery("a", created_at="2026-04-17T09:59:00Z")],
+            "failQueuedState": True,
+        }
+    )
+    assert result["ok"] is False
+    assert result["error"] == "queued state failed"
+    assert set(result["queueKeys"]) == {"a", "b"}
+    assert [call["type"] for call in result["calls"]] == ["terminal", "retry"]
+    assert result["calls"][0]["phase"] == "queued"
+    assert not any(call["type"] in {"send", "mark"} for call in result["calls"])
 
 
 def test_flush_marks_delivered_only_after_successful_send() -> None:

--- a/tests/test_pimux_parent_delivery_behavior.py
+++ b/tests/test_pimux_parent_delivery_behavior.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Behavior checks for pimux parent delivery and recovery helpers."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+PARENT_DELIVERY_RUNTIME = PROJECT_ROOT / "packages" / "pi-ac-workflow" / "extensions" / "pimux" / "parent-delivery.ts"
+
+NODE_RUNTIME_EVAL = """
+import { pathToFileURL } from "node:url";
+
+const helperPath = process.argv[1];
+const payload = JSON.parse(process.argv[2]);
+const runtime = await import(pathToFileURL(helperPath).href);
+const writeJson = (value) => process.stdout.write(JSON.stringify(value ?? null));
+
+if (payload.action === "flush") {
+  const queue = new Map(payload.deliveries.map((delivery) => [delivery.key, delivery]));
+  const calls = [];
+  try {
+    const result = await runtime.flushQueuedParentDeliveries({
+      queue,
+      makeBatchId: () => "batch-1",
+      updateTerminalNotificationState: async (deliveries, batchId, phase) => {
+        calls.push({ type: "terminal", phase, batchId, keys: deliveries.map((delivery) => delivery.key) });
+      },
+      sendParentMessage: (batchId, deliveries) => {
+        calls.push({ type: "send", batchId, keys: deliveries.map((delivery) => delivery.key) });
+        if (payload.failSend) throw new Error("send failed");
+      },
+      markParentDeliveriesDelivered: async (deliveries) => {
+        calls.push({ type: "mark", eventIds: deliveries.flatMap((delivery) => delivery.eventIds) });
+        if (payload.failMark) throw new Error("mark failed");
+      },
+      scheduleRetry: () => calls.push({ type: "retry" }),
+    });
+    writeJson({ ok: true, result, queueKeys: [...queue.keys()], calls });
+  } catch (error) {
+    writeJson({ ok: false, error: error instanceof Error ? error.message : String(error), queueKeys: [...queue.keys()], calls });
+  }
+  process.exit(0);
+}
+
+if (payload.action === "terminal_notification") {
+  writeJson(runtime.hasDeliveredTerminalNotification(payload.parentState, payload.identity));
+  process.exit(0);
+}
+
+if (payload.action === "watchdog") {
+  writeJson(runtime.shouldNotifyInactivityWatchdog(payload.input));
+  process.exit(0);
+}
+
+if (payload.action === "ping_gate") {
+  writeJson(runtime.shouldSendStatusRequestProbe(payload.activity));
+  process.exit(0);
+}
+
+throw new Error(`Unsupported action: ${payload.action}`);
+""".strip()
+
+
+def run_runtime(payload: dict[str, Any]) -> Any:
+    """Execute the parent-delivery helper through Node and parse JSON output."""
+    result = subprocess.run(
+        [
+            "node",
+            "--experimental-strip-types",
+            "--input-type=module",
+            "--eval",
+            NODE_RUNTIME_EVAL,
+            str(PARENT_DELIVERY_RUNTIME),
+            json.dumps(payload),
+        ],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        "Node parent-delivery helper execution failed.\n"
+        f"STDOUT:\n{result.stdout}\n"
+        f"STDERR:\n{result.stderr}"
+    )
+    return json.loads(result.stdout)
+
+
+def delivery(key: str, *, event_ids: list[str] | None = None, created_at: str = "2026-04-17T10:00:00Z") -> dict[str, Any]:
+    """Build a synthetic queued parent delivery."""
+    return {
+        "key": key,
+        "bridgeDir": f"/tmp/{key}",
+        "launch": {"agentId": f"agent-{key}"},
+        "content": f"content {key}",
+        "triggerTurn": True,
+        "eventIds": event_ids or [f"evt-{key}"],
+        "createdAt": created_at,
+    }
+
+
+def test_flush_requeues_deliveries_when_send_fails() -> None:
+    """A failed parent send should leave deliveries pending and avoid delivered acknowledgements."""
+    result = run_runtime(
+        {
+            "action": "flush",
+            "deliveries": [delivery("b"), delivery("a", created_at="2026-04-17T09:59:00Z")],
+            "failSend": True,
+        }
+    )
+    assert result["ok"] is False
+    assert result["error"] == "send failed"
+    assert set(result["queueKeys"]) == {"a", "b"}
+    assert [call["type"] for call in result["calls"]] == ["terminal", "send", "retry"]
+    assert not any(call["type"] == "mark" for call in result["calls"])
+
+
+def test_flush_marks_delivered_only_after_successful_send() -> None:
+    """Delivered IDs should be acknowledged after send succeeds, before terminal delivery metadata is final."""
+    result = run_runtime(
+        {
+            "action": "flush",
+            "deliveries": [delivery("b"), delivery("a", event_ids=["evt-a1", "evt-a2"], created_at="2026-04-17T09:59:00Z")],
+        }
+    )
+    assert result["ok"] is True
+    assert result["queueKeys"] == []
+    assert [call["type"] for call in result["calls"]] == ["terminal", "send", "mark", "terminal"]
+    assert result["calls"][0]["phase"] == "queued"
+    assert result["calls"][1]["keys"] == ["a", "b"]
+    assert result["calls"][2]["eventIds"] == ["evt-a1", "evt-a2", "evt-b"]
+    assert result["calls"][3]["phase"] == "delivered"
+
+
+def test_terminal_notification_identity_prevents_duplicate_delivered_notifications() -> None:
+    """Only an already-delivered matching terminal identity should suppress re-notification."""
+    parent_state = {
+        "terminalNotificationDeliveredAt": "2026-04-17T10:05:00Z",
+        "terminalState": "settled_completion",
+        "terminalEventId": "evt-closeout",
+    }
+    identity = {"terminalState": "settled_completion", "terminalEventId": "evt-closeout"}
+    assert run_runtime({"action": "terminal_notification", "parentState": parent_state, "identity": identity}) is True
+    assert run_runtime(
+        {
+            "action": "terminal_notification",
+            "parentState": parent_state,
+            "identity": {"terminalState": "settled_completion", "terminalEventId": "evt-other"},
+        }
+    ) is False
+    assert run_runtime(
+        {
+            "action": "terminal_notification",
+            "parentState": {"terminalState": "settled_completion", "terminalEventId": "evt-closeout"},
+            "identity": identity,
+        }
+    ) is False
+
+
+def test_watchdog_notifies_once_per_quiet_window() -> None:
+    """The inactivity watchdog should suppress duplicate notifications within the same quiet window."""
+    base_input = {
+        "activity": {"activityState": "running_quiet", "quietForMs": 700_000},
+        "lastActivity": "2026-04-17T10:00:00Z",
+        "nowMs": 1_776_420_600_000,
+        "thresholdMs": 600_000,
+    }
+    assert run_runtime({"action": "watchdog", "input": base_input}) is True
+    assert run_runtime(
+        {
+            "action": "watchdog",
+            "input": {**base_input, "lastNotifiedAt": "2026-04-17T10:05:00Z", "nowMs": 1_776_420_360_000},
+        }
+    ) is False
+    assert run_runtime(
+        {
+            "action": "watchdog",
+            "input": {**base_input, "lastNotifiedAt": "2026-04-17T10:05:00Z", "nowMs": 1_776_421_200_000},
+        }
+    ) is True
+    assert run_runtime(
+        {
+            "action": "watchdog",
+            "input": {**base_input, "activity": {"activityState": "running_recent_activity", "quietForMs": 10_000}},
+        }
+    ) is False
+
+
+def test_ping_agent_probe_gate_blocks_settled_and_missing_agents() -> None:
+    """Status probes should only be sent to bridge-running agents with a live or inspectable session."""
+    assert run_runtime(
+        {"action": "ping_gate", "activity": {"bridgeSettlementState": "running", "activityState": "running_quiet"}}
+    ) is True
+    assert run_runtime(
+        {"action": "ping_gate", "activity": {"bridgeSettlementState": "settled_completion", "activityState": "settled"}}
+    ) is False
+    assert run_runtime(
+        {"action": "ping_gate", "activity": {"bridgeSettlementState": "running", "activityState": "missing_session"}}
+    ) is False
+    assert run_runtime(
+        {"action": "ping_gate", "activity": {"bridgeSettlementState": "running", "activityState": "terminated"}}
+    ) is False

--- a/tests/test_pimux_runtime_surface.py
+++ b/tests/test_pimux_runtime_surface.py
@@ -67,8 +67,10 @@ def test_runtime_has_inactivity_watchdog_monitor() -> None:
     assert "processInactivityWatchdog" in text
     assert "pimux inactivity watchdog" in text
     assert "ensureBackgroundMonitor(ctx);" in text
-    assert "void reconcileParentBridgeWatchers(ctx);" in text
-    assert "void processInactivityWatchdog(ctx);" in text
+    assert "function runBackgroundTask(task: Promise<void>): void" in text
+    assert "runBackgroundTask(processBridgeDeliveries(bridgeDir, getSessionKey(ctx), ctx));" in text
+    assert "runBackgroundTask(reconcileParentBridgeWatchers(ctx));" in text
+    assert "runBackgroundTask(processInactivityWatchdog(ctx));" in text
 
 
 def test_ui_selectors_render_string_labels_instead_of_objects() -> None:

--- a/tests/test_pimux_runtime_surface.py
+++ b/tests/test_pimux_runtime_surface.py
@@ -23,6 +23,54 @@ def test_parent_runtime_auto_finalizes_terminal_child_reports() -> None:
     assert "events = await finalizeManagedAgentAfterTerminalReport(launch, ctx);" in text
 
 
+def test_parent_runtime_batches_and_retries_terminal_delivery() -> None:
+    """Terminal closeout notification should go through a durable batched parent queue."""
+    index_text = PIMUX_INDEX.read_text()
+    bridge_text = PIMUX_BRIDGE.read_text()
+    assert "interface QueuedParentDelivery" in index_text
+    assert "const parentDeliveryQueue = new Map<string, QueuedParentDelivery>();" in index_text
+    assert "const buildParentDeliveryBatchContent" in index_text
+    assert "# pimux reports: ${deliveries.length} updates" in index_text
+    assert "terminalNotificationDeliveredAt" in bridge_text
+    assert "terminalNotificationAttemptCount" in bridge_text
+    assert "!notificationDelivered" in index_text
+    assert "key: `settlement:${bridgeDir}:${settlement.terminalEvent?.eventId ?? settlement.settledState}`" in index_text
+    assert "const processingParentBridges = new Map<string, ParentBridgeProcessingState>();" in index_text
+    assert "existing.rerunRequested = true;" in index_text
+
+
+def test_activity_and_ping_agent_surface_is_available() -> None:
+    """pimux should expose deterministic activity checks and active status probes."""
+    index_text = PIMUX_INDEX.read_text()
+    schema_text = (PIMUX_PACKAGE_DIR / "schema.ts").read_text()
+    settlement_text = (PIMUX_PACKAGE_DIR / "settlement.ts").read_text()
+    registry_text = PIMUX_REGISTRY.read_text()
+    render_text = PIMUX_RENDER.read_text()
+    assert '"activity"' in schema_text
+    assert '"ping_agent"' in schema_text
+    assert 'case "activity": {' in index_text
+    assert "async function resolveManagedAgentStatus(" in index_text
+    assert "const status = await resolveManagedAgentStatus(ctx, target);" in index_text
+    assert 'case "ping_agent": {' in index_text
+    assert 'case "ping": {' in index_text
+    assert 'type: "status_request"' in index_text
+    assert '| "status_request"' in settlement_text
+    assert "buildAgentActivitySnapshot" in registry_text
+    assert "formatAgentActivitySnapshot" in registry_text
+    assert "pimux status_request response contract" in render_text
+
+
+def test_runtime_has_inactivity_watchdog_monitor() -> None:
+    """The extension should perform background reconciliation and inactivity watchdog notification."""
+    text = PIMUX_INDEX.read_text()
+    assert "BACKGROUND_MONITOR_INTERVAL_MS" in text
+    assert "processInactivityWatchdog" in text
+    assert "pimux inactivity watchdog" in text
+    assert "ensureBackgroundMonitor(ctx);" in text
+    assert "void reconcileParentBridgeWatchers(ctx);" in text
+    assert "void processInactivityWatchdog(ctx);" in text
+
+
 def test_ui_selectors_render_string_labels_instead_of_objects() -> None:
     """The open/tree pickers should pass display strings to ctx.ui.select."""
     text = PIMUX_INDEX.read_text()
@@ -121,7 +169,7 @@ def test_parent_control_plane_lock_is_extension_enforced() -> None:
     assert 'CONTROL_PLANE_INACTIVITY_WATCHDOG_MS' in helper_text
     assert 'Do not poll pimux; wait for delivered child activity.' in helper_text
     assert 'Do not use Bash sleep/wait loops for supervision' in helper_text
-    assert 'status/capture/tree/list/open are recovery-only' in helper_text
+    assert 'status/activity/capture/tree/list/open are recovery-only' in helper_text
     assert 'Wait for a delivered child report before sending messages' in helper_text
     assert 'A recovery send_message already went out for the current activity window.' in helper_text
     assert 'Terminal settlement is ready. Use one final pimux status check, then stop supervising this child.' in helper_text

--- a/tests/test_pimux_runtime_surface.py
+++ b/tests/test_pimux_runtime_surface.py
@@ -27,7 +27,8 @@ def test_parent_runtime_batches_and_retries_terminal_delivery() -> None:
     """Terminal closeout notification should go through a durable batched parent queue."""
     index_text = PIMUX_INDEX.read_text()
     bridge_text = PIMUX_BRIDGE.read_text()
-    assert "interface QueuedParentDelivery" in index_text
+    parent_delivery_text = (PIMUX_PACKAGE_DIR / "parent-delivery.ts").read_text()
+    assert "interface QueuedParentDelivery" in parent_delivery_text
     assert "const parentDeliveryQueue = new Map<string, QueuedParentDelivery>();" in index_text
     assert "const buildParentDeliveryBatchContent" in index_text
     assert "# pimux reports: ${deliveries.length} updates" in index_text
@@ -43,16 +44,20 @@ def test_parent_delivery_ack_happens_after_successful_send() -> None:
     """Deliverable bridge events should not be durably acknowledged before sendMessage succeeds."""
     index_text = PIMUX_INDEX.read_text()
     bridge_text = PIMUX_BRIDGE.read_text()
+    parent_delivery_text = (PIMUX_PACKAGE_DIR / "parent-delivery.ts").read_text()
     deliverable_block = index_text.split("if (shouldDeliverBridgeEventToParent(event)) {", 1)[1].split(
         "} else if (!terminalReport) {",
         1,
     )[0]
     assert "enqueueParentDelivery(" in deliverable_block
     assert "delivered.add(event.eventId)" not in deliverable_block
-    assert "const markParentDeliveriesDelivered = async (deliveries: QueuedParentDelivery[]): Promise<void> => {" in index_text
+    assert "await flushQueuedParentDeliveries({" in index_text
+    assert "markParentDeliveriesDelivered," in index_text
+    assert "sendParentMessage:" in index_text
+    assert "await options.markParentDeliveriesDelivered(deliveries);" in parent_delivery_text
+    assert "await options.updateTerminalNotificationState(deliveries, batchId, \"delivered\");" in parent_delivery_text
     assert "eventIds.push(...delivery.eventIds);" in index_text
     assert "parentState.deliveredEventIds = [...delivered].slice(-500);" in index_text
-    assert "await markParentDeliveriesDelivered(deliveries);\n\t\t\tawait updateTerminalNotificationState(deliveries, batchId, \"delivered\");" in index_text
     assert "deliveredEventIds: uniqueStrings([...(current.deliveredEventIds ?? []), ...(next.deliveredEventIds ?? [])]).slice(-500)," in bridge_text
 
 
@@ -75,6 +80,7 @@ def test_activity_and_ping_agent_surface_is_available() -> None:
     assert "buildAgentActivitySnapshot" in registry_text
     assert "formatAgentActivitySnapshot" in registry_text
     assert "pimux status_request response contract" in render_text
+    assert 'throw new Error("ping requires target")' not in index_text
 
 
 def test_runtime_has_inactivity_watchdog_monitor() -> None:
@@ -191,11 +197,11 @@ def test_parent_control_plane_lock_is_extension_enforced() -> None:
     assert 'status/activity/capture/tree/list/open are recovery-only' in helper_text
     assert 'Wait for a delivered child report before sending messages' in helper_text
     assert 'A recovery send_message already went out for the current activity window.' in helper_text
-    assert 'Terminal settlement is ready. Use one final pimux status check, then stop supervising this child.' in helper_text
+    assert 'Terminal settlement is ready. Use one final pimux status or activity check, then stop supervising this child.' in helper_text
     assert 'PIMUX HAPPY-PATH DISCIPLINE: this run is notify-first, not poll-first.' in helper_text
     assert 'FIRST: do not poll pimux and do not use Bash sleep/wait loops; wait for delivered child activity.' in helper_text
     assert 'Allowed happy-path sequence: spawn -> wait for child report -> send_message once if needed -> wait for closeout -> final status verification.' in helper_text
-    assert 'after terminal settlement, use one final pimux status check before advancing.' in helper_text
+    assert 'after terminal settlement, use one final pimux status or activity check before advancing.' in helper_text
     assert 'Progress is non-terminal; question is terminal waiting-on-parent settlement.' in text
     assert 'For same-session child questions that must continue, use report_parent(progress, requiresResponse=true), not question.' in text
     assert 'For same-session parent input that you need before continuing, emit progress with requiresResponse=true.' in bridge_text

--- a/tests/test_pimux_runtime_surface.py
+++ b/tests/test_pimux_runtime_surface.py
@@ -39,6 +39,23 @@ def test_parent_runtime_batches_and_retries_terminal_delivery() -> None:
     assert "existing.rerunRequested = true;" in index_text
 
 
+def test_parent_delivery_ack_happens_after_successful_send() -> None:
+    """Deliverable bridge events should not be durably acknowledged before sendMessage succeeds."""
+    index_text = PIMUX_INDEX.read_text()
+    bridge_text = PIMUX_BRIDGE.read_text()
+    deliverable_block = index_text.split("if (shouldDeliverBridgeEventToParent(event)) {", 1)[1].split(
+        "} else if (!terminalReport) {",
+        1,
+    )[0]
+    assert "enqueueParentDelivery(" in deliverable_block
+    assert "delivered.add(event.eventId)" not in deliverable_block
+    assert "const markParentDeliveriesDelivered = async (deliveries: QueuedParentDelivery[]): Promise<void> => {" in index_text
+    assert "eventIds.push(...delivery.eventIds);" in index_text
+    assert "parentState.deliveredEventIds = [...delivered].slice(-500);" in index_text
+    assert "await markParentDeliveriesDelivered(deliveries);\n\t\t\tawait updateTerminalNotificationState(deliveries, batchId, \"delivered\");" in index_text
+    assert "deliveredEventIds: uniqueStrings([...(current.deliveredEventIds ?? []), ...(next.deliveredEventIds ?? [])]).slice(-500)," in bridge_text
+
+
 def test_activity_and_ping_agent_surface_is_available() -> None:
     """pimux should expose deterministic activity checks and active status probes."""
     index_text = PIMUX_INDEX.read_text()


### PR DESCRIPTION
## Summary

Hardens pimux parent delivery and supervision recovery so child closeouts, progress updates, and live-inspection requests are handled reliably.

- Adds retry-safe parent-delivery batching with post-send acknowledgements.
- Adds deterministic `activity` checks and correlated `ping_agent` probes.
- Allows final settlement verification via `status` or `activity`.
- Allows `open` during supervision only when the user explicitly asks to watch live.

## Test Plan

- [x] `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider tests/test_pimux_*.py`
- [x] `PYTHONDONTWRITEBYTECODE=1 uv run ruff check --fix tests/test_pimux_control_plane.py tests/test_pimux_parent_delivery_behavior.py tests/test_pimux_runtime_surface.py`
- [x] `PYTHONDONTWRITEBYTECODE=1 uv run pyright tests/test_pimux_control_plane.py tests/test_pimux_parent_delivery_behavior.py tests/test_pimux_runtime_surface.py`

## Files Changed

- `packages/pi-ac-workflow/extensions/pimux/` - parent delivery, activity/ping, watchdog, and supervision guard updates
- `tests/test_pimux_*` - behavioral and surface coverage
- `CHANGELOG.md` - unreleased entry update

Generated with pi
