### PR TITLE
docs(pi): add upstream Pi attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to agentic-config.
 
 ### Added
 
-- Docs: add upstream Pi attribution, including `pi.dev`, `badlogic/pi-mono`, `@mariozechner/pi-coding-agent`, and `@mariozechner/pi-ai` references plus package ownership boundaries.
+- Docs: add upstream Pi attribution, including `pi.dev`, `badlogic/pi-mono`, `@mariozechner/pi-coding-agent`, and `@mariozechner/pi-ai` references, MIT license notes, and package ownership boundaries.
 - `pi-ac-workflow`: add deterministic `pimux activity` checks and correlated `ping_agent` liveness probes for managed agents.
 - `pi-ac-workflow`: add behavioral parent-delivery coverage for retry, ack ordering, terminal notification dedupe, watchdog throttling, and ping gating.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to agentic-config.
 
 ### Added
 
+- Docs: add upstream Pi attribution, including `pi.dev`, `badlogic/pi-mono`, `@mariozechner/pi-coding-agent`, and `@mariozechner/pi-ai` references plus package ownership boundaries.
 - `pi-ac-workflow`: add deterministic `pimux activity` checks and correlated `ping_agent` liveness probes for managed agents.
 - `pi-ac-workflow`: add behavioral parent-delivery coverage for retry, ack ordering, terminal notification dedupe, watchdog throttling, and ping gating.
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Pi is supported today through a validated root umbrella package installable from
 
 For teams, prefer a committed `.pi/settings.json` pinned to a release tag. For local testing and development, use branch refs or direct local package paths as appropriate.
 
+### Upstream Pi attribution
+
+agentic-config ships third-party packages for Pi. Pi itself, including the CLI, package loader, extension API, and runtime, is maintained upstream at [pi.dev](https://pi.dev) and [badlogic/pi-mono](https://github.com/badlogic/pi-mono). The package surface here imports upstream Pi APIs such as [`@mariozechner/pi-coding-agent`](https://www.npmjs.com/package/@mariozechner/pi-coding-agent) and [`@mariozechner/pi-ai`](https://www.npmjs.com/package/@mariozechner/pi-ai) where needed.
+
+See [Upstream Pi attribution](docs/upstream-pi-attribution.md) for source links and the runtime ownership boundary.
+
 Inside `@agentic-config/pi-ac-workflow`, runtime ownership is deliberate: `pimux` is the package-owned tmux control plane, and `ac-workflow-mux`, `ac-workflow-mux-ospec`, and `ac-workflow-mux-roadmap` are structured wrappers on top of it. Generic long-lived tmux work stays on `pimux`; the shipped pi package no longer exposes a separate managed-agent surface.
 
 Quick chooser:
@@ -96,6 +102,7 @@ Core principles:
 - [pimux Workflow Topologies](docs/pimux-workflow-topologies.md) -- `pimux`, mux, ospec, and roadmap hierarchy guide
 - [Distribution Guide](docs/distribution.md) -- pi git-tag installs, Claude marketplace rollout, dev branch installs, and future npm notes
 - [Pi Package Adoption Guide](packages/README.md) -- primary git-tag installs, branch-based dev installs, local package-root testing, and future npm distribution notes
+- [Upstream Pi attribution](docs/upstream-pi-attribution.md) -- upstream Pi references and agentic-config package ownership boundaries
 - [Migration Guide v0.2.0](docs/migration-v0.2.0.md) -- Migrate from v0.1.x
 - [Uninstall Legacy (v0.1.x)](docs/migration-v0.2.0.md#step-1-remove-old-symlinks) -- Remove legacy symlink wiring
 - [Full Documentation Index](docs/index.md)

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -99,7 +99,9 @@ One `.claude/settings.json` commit replaces per-member setup instructions.
 
 ## Pi Package Distribution
 
-Pi package sources generally support npm, git, and local paths. For the current `agentic-config` monorepo package layout:
+Pi package sources generally support npm, git, and local paths. Pi itself is maintained upstream at [pi.dev](https://pi.dev) and [badlogic/pi-mono](https://github.com/badlogic/pi-mono). The packages in this repository are agentic-config packages that install into upstream Pi; they do not define the Pi CLI or core runtime. See [Upstream Pi attribution](upstream-pi-attribution.md) for the source links and package ownership boundary.
+
+For the current `agentic-config` monorepo package layout:
 - git-tag installs of the validated root umbrella package are the primary team and automation path
 - branch refs are the preferred repo-based path for local testing and development
 - local package-root installs remain useful for focused package validation
@@ -241,4 +243,5 @@ All customizations are isolated to the private fork.
 
 - [Getting Started](getting-started.md) -- pi and Claude Code setup
 - [Pi Package Adoption Guide](../packages/README.md) -- npm installs, alternative git installs, committed `.pi/settings.json`, and local pre-distribution testing
+- [Upstream Pi attribution](upstream-pi-attribution.md) -- upstream Pi references and agentic-config package ownership boundaries
 - [Migration Guide v0.2.0](migration-v0.2.0.md) -- Migrate from v0.1.x symlinks

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,6 +8,8 @@ Setup and first use of agentic-config across pi packages and Claude Code plugins
 - Claude Code CLI with plugin support (`claude plugin install` available) for Claude Code setup
 - Git (for Claude marketplace access and git-based pi installs)
 
+Pi is an upstream project separate from agentic-config. agentic-config packages install into Pi and use upstream Pi APIs where needed. See [Upstream Pi attribution](upstream-pi-attribution.md) for source links and ownership boundaries.
+
 ## Install for pi
 
 The current primary pi install path uses the validated root umbrella package from a git ref.
@@ -268,5 +270,6 @@ Pi:
 - [pimux Workflow Topologies](pimux-workflow-topologies.md) -- `pimux`, mux, ospec, and roadmap runtime guide
 - [Distribution Guide](distribution.md) -- pi git-tag installs, Claude marketplace rollout, dev branch installs, and future npm notes
 - [Pi Package Adoption Guide](../packages/README.md) -- primary git-tag installs, branch-based dev installs, local package-root testing, and future npm distribution notes
+- [Upstream Pi attribution](upstream-pi-attribution.md) -- upstream Pi references and agentic-config package ownership boundaries
 - [Migration Guide v0.2.0](migration-v0.2.0.md) -- Migrate from v0.1.x symlinks
 - [External Specs Storage](external-specs-storage.md) -- Configure external specs repository

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ Table of contents for agentic-config documentation.
 | [pimux Workflow Topologies](pimux-workflow-topologies.md) | How `pimux`, mux, ospec, and roadmap nest and communicate |
 | [Distribution Guide](distribution.md) | pi git-tag installs, Claude marketplace rollout, dev branch installs, and future npm notes |
 | [Pi Package Adoption Guide](../packages/README.md) | primary git-tag installs, branch-based dev installs, local package-root testing, and future npm distribution notes |
+| [Upstream Pi attribution](upstream-pi-attribution.md) | upstream Pi references and agentic-config package ownership boundaries |
 | [Migration Guide v0.2.0](migration-v0.2.0.md) | Migrate from v0.1.x symlinks to CC-native plugins |
 
 ## Reference

--- a/docs/pimux-workflow-topologies.md
+++ b/docs/pimux-workflow-topologies.md
@@ -1,6 +1,6 @@
 # pimux workflow topologies
 
-This guide describes tmux-backed workflow surfaces shipped by `@agentic-config/pi-ac-workflow`.
+This guide describes tmux-backed workflow surfaces shipped by `@agentic-config/pi-ac-workflow`. These are agentic-config package surfaces that install into upstream Pi. They are not upstream Pi runtime features. See [Upstream Pi attribution](upstream-pi-attribution.md) for the package ownership boundary.
 
 ## Naming contract
 

--- a/docs/plugin-catalog.md
+++ b/docs/plugin-catalog.md
@@ -26,7 +26,7 @@ Complete catalog of agentic-config skills organized by plugin.
 | `product-manager` | Decomposes large features into concrete development phases with DAG dependencies |
 
 In pi, canonical shipped IDs are `ac-workflow-mux`, `ac-workflow-mux-ospec`, and `ac-workflow-mux-roadmap`, with user-facing aliases `mux`, `mux-ospec`, and `mux-roadmap`.
-`pimux` remains runtime/tooling only.
+`pimux` remains runtime/tooling only. These are agentic-config package surfaces that run on upstream Pi; see [Upstream Pi attribution](upstream-pi-attribution.md) for the boundary.
 
 ## ac-git (7 skills)
 
@@ -123,4 +123,5 @@ Rules:
 - [Getting Started](getting-started.md) -- Setup and first use
 - [Composition Hierarchy](composition-hierarchy.md) -- L0-L4 layer architecture design doc
 - [pimux Workflow Topologies](pimux-workflow-topologies.md) -- `pimux`, mux, ospec, and roadmap runtime shapes
+- [Upstream Pi attribution](upstream-pi-attribution.md) -- upstream Pi references and agentic-config package ownership boundaries
 - [Distribution Guide](distribution.md) -- Team adoption tiers

--- a/docs/upstream-pi-attribution.md
+++ b/docs/upstream-pi-attribution.md
@@ -1,0 +1,46 @@
+# Upstream Pi attribution
+
+agentic-config ships third-party Pi packages, skills, and extensions. Pi itself is a separate upstream project. This page records the upstream references used by the Pi package surface in this repository and the ownership boundary between Pi and agentic-config.
+
+## Upstream references
+
+| Surface | Reference |
+|---------|-----------|
+| Pi project website | <https://pi.dev> |
+| Pi monorepo | <https://github.com/badlogic/pi-mono> |
+| Pi coding agent npm package | <https://www.npmjs.com/package/@mariozechner/pi-coding-agent> |
+| Pi coding agent source package | <https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent> |
+| Pi AI npm package | <https://www.npmjs.com/package/@mariozechner/pi-ai> |
+| Pi AI source package | <https://github.com/badlogic/pi-mono/tree/main/packages/ai> |
+
+The upstream package names are listed as their public npm identifiers because agentic-config imports those packages directly in its Pi extension packages.
+
+## Ownership boundary
+
+Upstream Pi provides the CLI, package loader, extension API, core tool registration surface, auth/model helpers, session runtime, and terminal UI that Pi packages run on.
+
+agentic-config provides the packages under `@agentic-config/pi-*`, the generated skills, package-local extensions, hook compatibility layers, documentation, and workflow runtimes shipped from this repository.
+
+Important boundaries:
+
+- `pimux` is an agentic-config runtime extension shipped by `@agentic-config/pi-ac-workflow`. It is not an upstream Pi feature.
+- `@agentic-config/pi-compat` is an agentic-config compatibility layer for this package set. It is not an upstream Pi package.
+- `ac-workflow-mux`, `ac-workflow-mux-ospec`, and `ac-workflow-mux-roadmap` are agentic-config workflow wrappers built on the package-owned `pimux` runtime.
+- References to "Pi packages" in this repository mean packages that install into Pi through `pi install`, not packages owned by the upstream Pi project unless explicitly named as upstream.
+
+## Direct upstream dependencies in this repository
+
+The current package set imports upstream Pi APIs directly from:
+
+- `@mariozechner/pi-coding-agent`
+- `@mariozechner/pi-ai`
+
+Those direct imports are currently used by `@agentic-config/pi-ac-tools` and `@agentic-config/pi-ac-workflow`. Other package roots install into Pi through package manifests, skills, bundled assets, and shared compatibility wiring.
+
+## Guidance for future docs
+
+When documenting Pi support in this repository:
+
+- Attribute Pi runtime behavior to upstream Pi and link to this page when the distinction matters.
+- Attribute `@agentic-config/pi-*`, `pimux`, `hook-compat`, generated skills, and workflow wrappers to agentic-config.
+- Avoid wording that suggests agentic-config owns the Pi CLI, Pi monorepo, or upstream `@mariozechner/*` packages.

--- a/docs/upstream-pi-attribution.md
+++ b/docs/upstream-pi-attribution.md
@@ -4,16 +4,16 @@ agentic-config ships third-party Pi packages, skills, and extensions. Pi itself 
 
 ## Upstream references
 
-| Surface | Reference |
-|---------|-----------|
-| Pi project website | <https://pi.dev> |
-| Pi monorepo | <https://github.com/badlogic/pi-mono> |
-| Pi coding agent npm package | <https://www.npmjs.com/package/@mariozechner/pi-coding-agent> |
-| Pi coding agent source package | <https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent> |
-| Pi AI npm package | <https://www.npmjs.com/package/@mariozechner/pi-ai> |
-| Pi AI source package | <https://github.com/badlogic/pi-mono/tree/main/packages/ai> |
+| Surface | Reference | License |
+|---------|-----------|---------|
+| Pi project website | <https://pi.dev> | MIT for the public upstream packages referenced here |
+| Pi monorepo | <https://github.com/badlogic/pi-mono> | MIT |
+| Pi coding agent npm package | <https://www.npmjs.com/package/@mariozechner/pi-coding-agent> | MIT |
+| Pi coding agent source package | <https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent> | MIT |
+| Pi AI npm package | <https://www.npmjs.com/package/@mariozechner/pi-ai> | MIT |
+| Pi AI source package | <https://github.com/badlogic/pi-mono/tree/main/packages/ai> | MIT |
 
-The upstream package names are listed as their public npm identifiers because agentic-config imports those packages directly in its Pi extension packages.
+The upstream package names are listed as their public npm identifiers because agentic-config imports those packages directly in its Pi extension packages. The MIT license entries above are taken from the public package metadata for the referenced upstream packages.
 
 ## Ownership boundary
 
@@ -27,6 +27,12 @@ Important boundaries:
 - `@agentic-config/pi-compat` is an agentic-config compatibility layer for this package set. It is not an upstream Pi package.
 - `ac-workflow-mux`, `ac-workflow-mux-ospec`, and `ac-workflow-mux-roadmap` are agentic-config workflow wrappers built on the package-owned `pimux` runtime.
 - References to "Pi packages" in this repository mean packages that install into Pi through `pi install`, not packages owned by the upstream Pi project unless explicitly named as upstream.
+
+## License boundary
+
+The upstream Pi packages referenced here are MIT licensed. agentic-config is also MIT licensed, but its `@agentic-config/pi-*` packages are separate third-party packages that install into upstream Pi.
+
+If this repository starts copying or bundling upstream Pi source files or assets directly, add the upstream MIT license notice alongside those copied materials. For the current direct-import and documentation-reference usage, this attribution page records the upstream license type and boundary.
 
 ## Direct upstream dependencies in this repository
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -2,6 +2,17 @@
 
 This directory contains the current pi package surface for `agentic-config`.
 
+## Upstream Pi dependency and attribution
+
+Pi is maintained upstream at [pi.dev](https://pi.dev) and [badlogic/pi-mono](https://github.com/badlogic/pi-mono). The packages in this directory are third-party agentic-config packages that install into upstream Pi through `pi install`.
+
+Direct upstream API imports currently use:
+
+- [`@mariozechner/pi-coding-agent`](https://www.npmjs.com/package/@mariozechner/pi-coding-agent), with source under [`packages/coding-agent`](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent)
+- [`@mariozechner/pi-ai`](https://www.npmjs.com/package/@mariozechner/pi-ai), with source under [`packages/ai`](https://github.com/badlogic/pi-mono/tree/main/packages/ai)
+
+See [docs/upstream-pi-attribution.md](../docs/upstream-pi-attribution.md) for the ownership boundary. In short: upstream Pi owns the CLI, package loader, extension API, and core runtime; agentic-config owns the `@agentic-config/pi-*` packages, generated skills, compatibility layers, package-local extensions, and `pimux` workflow runtime shipped here.
+
 ## Current shipped surface
 - `9` package roots total:
   - `@agentic-config/pi-compat`

--- a/packages/pi-ac-tools/README.md
+++ b/packages/pi-ac-tools/README.md
@@ -27,6 +27,12 @@
   - package-local `say` extension
   - package-local `web-search` extension
 
+## Upstream Pi attribution
+
+This package installs into upstream Pi and uses upstream Pi APIs for its package-local extensions. Direct imports include [`@mariozechner/pi-coding-agent`](https://www.npmjs.com/package/@mariozechner/pi-coding-agent) and [`@mariozechner/pi-ai`](https://www.npmjs.com/package/@mariozechner/pi-ai), whose source lives in [badlogic/pi-mono](https://github.com/badlogic/pi-mono).
+
+The `say` and `web-search` extensions are agentic-config package extensions. They are not upstream Pi features. See [Upstream Pi attribution](../../docs/upstream-pi-attribution.md) for the full boundary.
+
 ## Current surface
 ### Shipped generated skill surface
 - `ac-tools-ac-issue`

--- a/packages/pi-ac-workflow/README.md
+++ b/packages/pi-ac-workflow/README.md
@@ -17,6 +17,12 @@
   - `pimux` (runtime/tooling control plane)
   - `strict-mux-runtime` (strict ledger/runtime guard)
 
+## Upstream Pi attribution
+
+This package installs into upstream Pi and uses upstream Pi APIs for its package-local runtime extensions. Direct imports include [`@mariozechner/pi-coding-agent`](https://www.npmjs.com/package/@mariozechner/pi-coding-agent) and [`@mariozechner/pi-ai`](https://www.npmjs.com/package/@mariozechner/pi-ai), whose source lives in [badlogic/pi-mono](https://github.com/badlogic/pi-mono).
+
+`pimux`, `strict-mux-runtime`, and the `ac-workflow-*` wrappers are agentic-config package surfaces. They are not upstream Pi features. See [Upstream Pi attribution](../../docs/upstream-pi-attribution.md) for the full boundary.
+
 ## Naming and runtime boundary
 
 - canonical shipped workflow IDs stay `ac-workflow-mux`, `ac-workflow-mux-ospec`, `ac-workflow-mux-roadmap`

--- a/packages/pi-all/README.md
+++ b/packages/pi-all/README.md
@@ -6,6 +6,10 @@
 - Current exported pi resources: aggregation of the current shipped package set through bundled dependencies
 - Package-local first-party resources: none
 
+## Upstream Pi attribution
+
+This package aggregates agentic-config packages that install into upstream Pi. It does not provide or replace the upstream Pi CLI, package loader, extension API, or core runtime. See [Upstream Pi attribution](../../docs/upstream-pi-attribution.md) for links to [pi.dev](https://pi.dev), [badlogic/pi-mono](https://github.com/badlogic/pi-mono), and the upstream npm packages used by this repository.
+
 ## What this package aggregates today
 `@agentic-config/pi-all` is the one-shot install surface for the current shipped pi package set.
 

--- a/packages/pi-compat/README.md
+++ b/packages/pi-compat/README.md
@@ -5,6 +5,12 @@
 - Package topology status: `active`
 - Current capability state: `interactive-notebook-and-worker-wave-runtime-foundation`
 
+## Upstream Pi attribution
+
+This package provides agentic-config compatibility helpers for packages that install into upstream Pi. It is not an upstream Pi package. Upstream Pi is referenced at [pi.dev](https://pi.dev), [badlogic/pi-mono](https://github.com/badlogic/pi-mono), and the public npm packages such as [`@mariozechner/pi-coding-agent`](https://www.npmjs.com/package/@mariozechner/pi-coding-agent).
+
+See [Upstream Pi attribution](../../docs/upstream-pi-attribution.md) for the ownership boundary between upstream Pi runtime behavior and agentic-config package behavior.
+
 ## Current exported surface
 - Shared extension runtimes under `extensions/`
   - `hook-compat/` — shared compat pre-tool hook runtime plus registration helpers


### PR DESCRIPTION
## Summary

Adds a canonical upstream Pi attribution page and links it from the main docs and package README surfaces. The update clarifies that agentic-config ships third-party Pi packages that run on upstream Pi, while upstream Pi owns the CLI, package loader, extension API, and core runtime.

- Adds upstream references for `pi.dev`, `badlogic/pi-mono`, `@mariozechner/pi-coding-agent`, and `@mariozechner/pi-ai`
- Documents the MIT license boundary for referenced upstream Pi packages
- Clarifies that `@agentic-config/pi-*`, `pimux`, `pi-compat`, generated skills, and workflow wrappers are agentic-config surfaces

### Root Cause

The existing docs described the Pi package surface but did not provide a single attribution and ownership-boundary reference for upstream Pi repositories and npm packages.

### Key Changes

**Canonical attribution:**
- Adds `docs/upstream-pi-attribution.md` with upstream links, direct dependency notes, MIT license notes, and future documentation guidance

**Top-level docs:**
- Links the attribution page from `README.md`, `docs/index.md`, `docs/getting-started.md`, `docs/distribution.md`, `docs/plugin-catalog.md`, and `docs/pimux-workflow-topologies.md`

**Package docs:**
- Adds upstream attribution and boundary notes to `packages/README.md`
- Adds package-specific notes for `pi-ac-tools`, `pi-ac-workflow`, `pi-compat`, and `pi-all`

**Changelog:**
- Records the documentation update under `[Unreleased]`

## Test Plan

- [x] Run markdown whitespace validation: `git diff --check`
- [x] Verify upstream references are present with `rg`
- [x] Commit with pre-commit hook result: `PII_AUDIT: PASS`

## Files Changed

**Attribution docs:**
- `docs/upstream-pi-attribution.md` - New canonical upstream Pi attribution, license, and ownership-boundary page

**Top-level docs:**
- `README.md` - Adds attribution section and documentation link
- `docs/index.md` - Adds attribution page to the docs index
- `docs/getting-started.md` - Adds upstream Pi prerequisite note and see-also link
- `docs/distribution.md` - Adds Pi package distribution boundary note and see-also link
- `docs/plugin-catalog.md` - Clarifies `pimux` and mux wrappers as agentic-config package surfaces
- `docs/pimux-workflow-topologies.md` - Clarifies workflow topology ownership boundary

**Package docs:**
- `packages/README.md` - Adds upstream Pi dependency and attribution section
- `packages/pi-ac-tools/README.md` - Notes direct upstream Pi API imports for package-local extensions
- `packages/pi-ac-workflow/README.md` - Notes direct upstream Pi API imports for runtime extensions and clarifies `pimux` ownership
- `packages/pi-compat/README.md` - Clarifies compatibility package ownership boundary
- `packages/pi-all/README.md` - Clarifies umbrella package boundary

**Release notes:**
- `CHANGELOG.md` - Adds unreleased documentation entry

## Related

- **Spec**: Not applicable
- **Ticket**: Not applicable

Generated with pi