### PR TITLE
fix(pimux): suppress spawn during pending settlement

### DIFF
--- a/packages/pi-ac-workflow/extensions/pimux/control-plane.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/control-plane.ts
@@ -485,6 +485,39 @@ function isSettlementVerificationAction(action: string): boolean {
 	return SETTLEMENT_VERIFICATION_ACTIONS.has(action);
 }
 
+function isSpawnAction(action: string): boolean {
+	return action === "spawn";
+}
+
+function getStringInputValue(input: Record<string, unknown> | undefined, key: string): string | undefined {
+	const value = input?.[key];
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function getPimuxRequestedTarget(action: string, input: Record<string, unknown> | undefined): string | undefined {
+	return getStringInputValue(input, "target") ?? (isSpawnAction(action) ? getStringInputValue(input, "agentId") : undefined);
+}
+
+function getToolResultAgentId(details: Record<string, unknown> | undefined): string | undefined {
+	const status = details?.status;
+	if (!status || typeof status !== "object") return undefined;
+	const record = (status as { record?: unknown }).record;
+	if (!record || typeof record !== "object") return undefined;
+	const agentId = (record as { agentId?: unknown }).agentId;
+	return typeof agentId === "string" && agentId.trim() ? agentId.trim() : undefined;
+}
+
+function isPendingSettlementVerificationTarget(supervision: Pick<NoPollingSupervisionState, "lastSpawnedAgentId">, requestedTarget: string | undefined): boolean {
+	if (!requestedTarget || requestedTarget === "last") return true;
+	return Boolean(supervision.lastSpawnedAgentId) && requestedTarget === supervision.lastSpawnedAgentId;
+}
+
+function buildSettlementPendingDetail(supervision: Pick<NoPollingSupervisionState, "lastSpawnedAgentId">, action: string, requestedTarget?: string): string {
+	const relatedAgentId = supervision.lastSpawnedAgentId ?? "unknown";
+	const requested = requestedTarget ? ` Requested target: ${requestedTarget}.` : "";
+	return `Terminal settlement is ready for ${relatedAgentId}. Use one final pimux status or activity check for ${relatedAgentId}, then stop supervising this child before ${action}.${requested}`;
+}
+
 function isTrackedDirectChild(lock: ControlPlaneLockState, agentId?: string): boolean {
 	return !lock.lastSpawnedAgentId || !agentId || lock.lastSpawnedAgentId === agentId;
 }
@@ -627,14 +660,16 @@ export function evaluateNoPollingSupervisionToolCall(
 	if (isPimuxTool(event.toolName)) {
 		const action = String(event.input?.action ?? "").trim();
 		if (!action) return { allow: true };
+		const requestedTarget = getPimuxRequestedTarget(action, event.input);
+		if (isSpawnAction(action)) return { allow: true };
+		if (supervision.settlementVerificationPending) {
+			if (isSettlementVerificationAction(action) && isPendingSettlementVerificationTarget(supervision, requestedTarget)) return { allow: true };
+			return buildNoPollingReason(buildSettlementPendingDetail(supervision, action, requestedTarget));
+		}
 		if (isExplicitOpenAction(action, context)) return { allow: true };
 		if (isExplicitPassiveInspectionAction(action, context)) return { allow: true };
 		if (isExplicitChildInstructionAction(action, context)) return { allow: true };
 		if (isExplicitChildProbeAction(action, context)) return { allow: true };
-		if (supervision.settlementVerificationPending && isSettlementVerificationAction(action)) return { allow: true };
-		if (supervision.settlementVerificationPending) {
-			return buildNoPollingReason("Terminal settlement is ready. Use one final pimux status or activity check, then stop supervising this child.");
-		}
 		if (isSupervisionCheckAction(action)) {
 			if (isInactivityWatchdogReached(supervision, now)) return { allow: true };
 			return buildNoPollingReason(
@@ -785,9 +820,11 @@ export function updateNoPollingSupervisionForToolResult(
 ): NoPollingSupervisionState | undefined {
 	if (!supervision?.active || !isPimuxTool(event.toolName)) return supervision;
 	const action = String(event.details?.action ?? "").trim();
-	if (!action || event.isError || typeof event.details?.error === "string") return supervision;
+	if (!action || event.isError || typeof event.details?.error === "string" || event.details?.suppressed === true) return supervision;
 	const occurredAt = resolveNowIso(now);
 	if (supervision.settlementVerificationPending && isSettlementVerificationAction(action)) {
+		const verifiedAgentId = getToolResultAgentId(event.details);
+		if (verifiedAgentId && supervision.lastSpawnedAgentId && verifiedAgentId !== supervision.lastSpawnedAgentId) return supervision;
 		return {
 			...supervision,
 			active: false,
@@ -831,7 +868,7 @@ export function updateControlPlaneLockForToolResult(
 	if (!isPimuxTool(event.toolName)) return lock;
 	const action = String(event.details?.action ?? "").trim();
 	if (!action) return lock;
-	if (event.isError || typeof event.details?.error === "string") return lock;
+	if (event.isError || typeof event.details?.error === "string" || event.details?.suppressed === true) return lock;
 
 	const occurredAt = resolveNowIso(now);
 	if (action === "spawn") {

--- a/packages/pi-ac-workflow/extensions/pimux/docs/commands.md
+++ b/packages/pi-ac-workflow/extensions/pimux/docs/commands.md
@@ -83,6 +83,8 @@ Parent-side interface delivery should also show parent -> child bridge messages 
 
 After a terminal `report_parent`, pimux first records `terminal_report_received`, finalizes the managed session, then reports a settled state only after exit evidence exists. If exit evidence does not arrive before timeout, status/activity surface `terminal_report_exit_timeout` with recovery guidance. Terminal settlement notifications remain retryable until the parent delivery queue records delivery.
 
+If a new `spawn` is attempted while terminal settlement verification is pending, pimux fails closed with an explicit `Spawn suppressed` result that names the pending related child instead of creating an ambiguous second child.
+
 ## Inspection
 
 - `list` for current-session agents by default

--- a/packages/pi-ac-workflow/extensions/pimux/docs/protocol.md
+++ b/packages/pi-ac-workflow/extensions/pimux/docs/protocol.md
@@ -80,7 +80,7 @@ For explicit mux-family wrappers, the notify-first default is stricter:
 - treat `status`, `activity`, `capture`, `tree`, `list`, and `open` as recovery-only tools for suspected stall/protocol violation/failure or the inactivity-only watchdog; `open` is also allowed for explicit user live-inspection requests
 - use `activity` when deterministic bridge/process state is enough and pane capture is unnecessary
 - use `ping_agent` only as a neutral active recovery probe; the child must answer the `status_request` with `progress` if still working or a terminal report only if quality-gated completion/blocker/failure is real
-- after terminal settlement, use one final `pimux status` or `pimux activity` check before advancing
+- after terminal settlement, use one final `pimux status` or `pimux activity` check for the pending child before advancing or dispatching another child
 
 Do not poll pimux or use Bash sleep/wait loops; wait for delivered child activity. One targeted `status` / `capture` check at a real recovery decision point is fine. Continuous polling is not. Do not nudge children toward closeout; quality, accuracy, and prompt/spec fidelity outrank speed.
 

--- a/packages/pi-ac-workflow/extensions/pimux/index.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/index.ts
@@ -1214,6 +1214,28 @@ function buildToolResult(text: string, details: Record<string, unknown>) {
 	};
 }
 
+function buildSpawnSuppression(
+	request: { agentId?: string },
+	supervision: NoPollingSupervisionState | undefined,
+): { text: string; details: Record<string, unknown> } | undefined {
+	if (!supervision?.active || supervision.settlementVerificationPending !== true) return undefined;
+	const requestedAgentId = request.agentId?.trim() || undefined;
+	const relatedAgentId = supervision.lastSpawnedAgentId;
+	const relatedLabel = relatedAgentId ?? "unknown";
+	const requested = requestedAgentId ? ` Requested agent: ${requestedAgentId}.` : "";
+	const details: Record<string, unknown> = {
+		action: "spawn",
+		suppressed: true,
+		reason: "terminal_settlement_verification_pending",
+	};
+	if (requestedAgentId) details.requestedAgentId = requestedAgentId;
+	if (relatedAgentId) details.relatedAgentId = relatedAgentId;
+	return {
+		text: `Spawn suppressed: terminal settlement verification is pending for ${relatedLabel}. Use pimux status or activity for ${relatedLabel} before dispatching another child.${requested}`,
+		details,
+	};
+}
+
 const CONTROL_PLANE_ACTIVE_TOOLS = ["pimux", "AskUserQuestion", "say"];
 const NO_POLLING_SPAWN_ECHO = "NO-POLL: do not poll pimux or use Bash sleep/wait loops; wait for delivered child activity.";
 const PARENT_DELIVERY_DEBOUNCE_MS = 75;
@@ -2013,7 +2035,14 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 
 		switch (subcommand) {
 			case "spawn": {
-				const record = await spawnManagedAgent(buildSpawnRequest(parsed, ctx), ctx);
+				const request = buildSpawnRequest(parsed, ctx);
+				const suppression = buildSpawnSuppression(request, noPollingSupervision);
+				if (suppression) {
+					if (ctx.hasUI) ctx.ui.notify(suppression.text, "warning");
+					else console.log(suppression.text);
+					return;
+				}
+				const record = await spawnManagedAgent(request, ctx);
 				const opened = record.visualMode === "iterm-opened";
 				const summary = `Spawned ${record.agentId} (${record.role ?? "worker"}, ${opened ? "opened in iTerm" : "headless"}). ${NO_POLLING_SPAWN_ECHO}`;
 				if (ctx.hasUI) ctx.ui.notify(summary, "info");
@@ -2446,23 +2475,24 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 			try {
 				switch (params.action) {
 					case "spawn": {
-						if (!params.prompt?.trim()) throw new Error("spawn requires prompt");
-						const record = await spawnManagedAgent(
-							{
-								agentId: params.agentId,
-								cwd: params.cwd ?? ctx.cwd,
-								model: params.model,
-								thinking: params.thinking,
-								prompt: params.prompt,
-								role: params.role,
-								goal: params.goal,
-								parentAgentId: params.parentAgentId,
-								rootAgentId: params.rootAgentId,
-								openIterm: params.openIterm,
-								contextBrief: params.contextBrief,
-							},
-							ctx,
-						);
+						const prompt = params.prompt;
+						if (!prompt?.trim()) throw new Error("spawn requires prompt");
+						const request: SpawnRequest = {
+							agentId: params.agentId,
+							cwd: params.cwd ?? ctx.cwd,
+							model: params.model,
+							thinking: params.thinking,
+							prompt,
+							role: params.role,
+							goal: params.goal,
+							parentAgentId: params.parentAgentId,
+							rootAgentId: params.rootAgentId,
+							openIterm: params.openIterm,
+							contextBrief: params.contextBrief,
+						};
+						const suppression = buildSpawnSuppression(request, noPollingSupervision);
+						if (suppression) return buildToolResult(suppression.text, suppression.details);
+						const record = await spawnManagedAgent(request, ctx);
 						return buildToolResult(`Spawned ${record.agentId} (${record.visualMode === "iterm-opened" ? "opened in iTerm" : "headless"}). ${NO_POLLING_SPAWN_ECHO}`, { action: params.action, agent: record });
 					}
 					case "open": {

--- a/tests/test_pimux_control_plane.py
+++ b/tests/test_pimux_control_plane.py
@@ -163,6 +163,21 @@ def no_polling_supervision(spawned_at: str = "2026-04-17T10:00:00Z") -> dict[str
     )
 
 
+def settled_no_polling_supervision() -> dict[str, Any]:
+    """Create no-polling supervision with terminal settlement verification pending."""
+    return run_runtime(
+        {
+            "action": "no_polling_terminal_settlement",
+            "supervision": no_polling_supervision(),
+            "event": {
+                "agentId": "pimux-worker-001",
+                "eventId": "evt-closeout-1",
+                "timestamp": "2026-04-17T10:03:00Z",
+            },
+        }
+    )
+
+
 def spawn_post_lock(spawned_at: str = "2026-04-17T10:00:00Z") -> dict[str, Any]:
     """Create a post-spawn mux-ospec lock at a fixed timestamp for pacing tests."""
     pre_spawn = run_runtime(
@@ -1141,18 +1156,7 @@ def test_no_polling_supervision_blocks_bash_sleep_wait_loops_but_allows_normal_c
 
 def test_no_polling_supervision_allows_one_final_status_or_activity_after_terminal_settlement() -> None:
     """Terminal settlement should reopen exactly one final status/activity check for verification."""
-    supervision = no_polling_supervision()
-    settled = run_runtime(
-        {
-            "action": "no_polling_terminal_settlement",
-            "supervision": supervision,
-            "event": {
-                "agentId": "pimux-worker-001",
-                "eventId": "evt-closeout-1",
-                "timestamp": "2026-04-17T10:03:00Z",
-            },
-        }
-    )
+    settled = settled_no_polling_supervision()
     allowed_status = run_runtime(
         {
             "action": "evaluate_no_polling_supervision",
@@ -1197,3 +1201,77 @@ def test_no_polling_supervision_allows_one_final_status_or_activity_after_termin
         }
     )
     assert allowed_after_supervision == {"allow": True}
+
+
+def test_no_polling_settlement_pending_does_not_pretool_block_spawn() -> None:
+    """Spawn must reach the executor so it can return a structured suppressed result."""
+    settled = settled_no_polling_supervision()
+    decision = run_runtime(
+        {
+            "action": "evaluate_no_polling_supervision",
+            "supervision": settled,
+            "event": {"toolName": "pimux", "input": {"action": "spawn", "agentId": "pimux-repro-new"}},
+            "now": "2026-04-17T10:04:00Z",
+        }
+    )
+    assert decision == {"allow": True}
+
+
+def test_no_polling_settlement_pending_wrong_target_verification_is_blocked_with_related_id() -> None:
+    """Final settlement verification should be scoped to the pending child."""
+    settled = settled_no_polling_supervision()
+    blocked_activity = run_runtime(
+        {
+            "action": "evaluate_no_polling_supervision",
+            "supervision": settled,
+            "event": {"toolName": "pimux", "input": {"action": "activity", "target": "pimux-repro-new"}},
+            "now": "2026-04-17T10:04:00Z",
+        }
+    )
+    assert blocked_activity["allow"] is False
+    assert "pimux-worker-001" in blocked_activity["reason"]
+    assert "pimux-repro-new" in blocked_activity["reason"]
+
+    blocked_list = run_runtime(
+        {
+            "action": "evaluate_no_polling_supervision",
+            "supervision": settled,
+            "event": {"toolName": "pimux", "input": {"action": "list"}},
+            "now": "2026-04-17T10:04:00Z",
+        }
+    )
+    assert blocked_list["allow"] is False
+    assert "pimux-worker-001" in blocked_list["reason"]
+
+
+def test_no_polling_final_verification_clears_only_for_related_agent() -> None:
+    """A successful final status/activity result for another agent must not settle this child."""
+    settled = settled_no_polling_supervision()
+    after_wrong_agent = run_runtime(
+        {
+            "action": "no_polling_tool_result",
+            "supervision": settled,
+            "event": {
+                "toolName": "pimux",
+                "details": {"action": "status", "status": {"record": {"agentId": "pimux-repro-new"}}},
+                "isError": False,
+            },
+            "now": "2026-04-17T10:03:05Z",
+        }
+    )
+    assert after_wrong_agent["active"] is True
+    assert after_wrong_agent["settlementVerificationPending"] is True
+
+    after_related_agent = run_runtime(
+        {
+            "action": "no_polling_tool_result",
+            "supervision": settled,
+            "event": {
+                "toolName": "pimux",
+                "details": {"action": "activity", "status": {"record": {"agentId": "pimux-worker-001"}}},
+                "isError": False,
+            },
+            "now": "2026-04-17T10:03:05Z",
+        }
+    )
+    assert after_related_agent["active"] is False

--- a/tests/test_pimux_runtime_surface.py
+++ b/tests/test_pimux_runtime_surface.py
@@ -242,6 +242,25 @@ def test_launcher_reports_startup_failures_and_exits_instead_of_dropping_to_a_sh
 
 
 
+def test_spawn_suppresses_dispatch_when_settlement_verification_is_pending() -> None:
+    """Spawn should return a structured suppression instead of bypassing pending settlement."""
+    text = PIMUX_INDEX.read_text()
+    assert "function buildSpawnSuppression(" in text
+    assert 'reason: "terminal_settlement_verification_pending"' in text
+    assert "requestedAgentId" in text
+    assert "relatedAgentId" in text
+
+    command_spawn_case = text.split('case "spawn": {', 1)[1].split('case "open": {', 1)[0]
+    assert "const suppression = buildSpawnSuppression(request, noPollingSupervision);" in command_spawn_case
+    assert "ctx.ui.notify(suppression.text, \"warning\")" in command_spawn_case
+    assert command_spawn_case.index("buildSpawnSuppression") < command_spawn_case.index("spawnManagedAgent")
+
+    tool_spawn_case = text.rsplit('case "spawn": {', 1)[1].split('case "open": {', 1)[0]
+    assert "const suppression = buildSpawnSuppression(request, noPollingSupervision);" in tool_spawn_case
+    assert "if (suppression) return buildToolResult(suppression.text, suppression.details);" in tool_spawn_case
+    assert tool_spawn_case.index("buildSpawnSuppression") < tool_spawn_case.index("spawnManagedAgent")
+
+
 def test_spawn_forwards_explicit_thinking_effort_to_child_pi() -> None:
     """pimux spawn should expose and forward Pi's standalone --thinking effort flag."""
     index_text = PIMUX_INDEX.read_text()


### PR DESCRIPTION
## Summary

Fixes ambiguous `pimux spawn` behavior while terminal settlement verification is pending.

### Root Cause
The no-polling guard blocked `spawn` before the executor could return structured spawn details.

### Key Changes
- Let `spawn` reach the executor, then fail closed with `Spawn suppressed` and related/requested agent ids.
- Scope final settlement verification to the pending child.
- Keep supervision active when verification resolves a different agent.

## Test Plan

- [x] `uv run pytest tests/test_pimux_control_plane.py tests/test_pimux_runtime_surface.py -q`
- [x] `uv run ruff check --fix tests/test_pimux_control_plane.py tests/test_pimux_runtime_surface.py`
- [x] `uv run pyright tests/test_pimux_control_plane.py tests/test_pimux_runtime_surface.py`
- [x] `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q`

## Files Changed

- `packages/pi-ac-workflow/extensions/pimux/*` - guard/runtime/docs fix
- `tests/test_pimux_*` - regressions

## Related

- **Spec**: `.specs/specs/2026/05/fix-pimux-spawn-settlement-guard/001-fix-pimux-spawn-settlement-guard.md`

Generated with pi