### PR TITLE
fix(pi): update upstream package scope

### DIFF
--- a/.pi/archive/extensions/pimux-local-runtime/index.ts
+++ b/.pi/archive/extensions/pimux-local-runtime/index.ts
@@ -1,7 +1,7 @@
 import { promises as fs, watch as watchFs } from "node:fs";
 import type { FSWatcher } from "node:fs";
 import * as path from "node:path";
-import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
 	appendBridgeEvent,
 	buildBridgeSessionEntry,

--- a/.pi/archive/extensions/pimux-local-runtime/schema.ts
+++ b/.pi/archive/extensions/pimux-local-runtime/schema.ts
@@ -1,5 +1,5 @@
-import { StringEnum } from "@mariozechner/pi-ai";
-import { Type } from "@sinclair/typebox";
+import { StringEnum } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
 
 export const PIMUX_PARAMS = Type.Object({
 	action: StringEnum(["spawn", "open", "list", "tree", "status", "capture", "send_message", "report_parent", "kill", "prune"] as const),

--- a/.pi/extensions/pimux/index.ts
+++ b/.pi/extensions/pimux/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 /**
  * Project-local pimux compatibility shim.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to agentic-config.
 
 ## [Unreleased]
 
+### Changed
+
+- Pi package imports and attribution now target the current `@earendil-works/*` upstream packages and `typebox` peer dependency.
+
 ## [0.3.1] - 2026-05-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For teams, prefer a committed `.pi/settings.json` pinned to a release tag. For l
 
 ### Upstream Pi attribution
 
-agentic-config ships third-party packages for Pi. Pi itself, including the CLI, package loader, extension API, and runtime, is maintained upstream at [pi.dev](https://pi.dev) and [badlogic/pi-mono](https://github.com/badlogic/pi-mono). The package surface here imports upstream Pi APIs such as [`@mariozechner/pi-coding-agent`](https://www.npmjs.com/package/@mariozechner/pi-coding-agent) and [`@mariozechner/pi-ai`](https://www.npmjs.com/package/@mariozechner/pi-ai) where needed.
+agentic-config ships third-party packages for Pi. Pi itself, including the CLI, package loader, extension API, and runtime, is maintained upstream at [pi.dev](https://pi.dev) and [earendil-works/pi](https://github.com/earendil-works/pi). The package surface here imports upstream Pi APIs such as [`@earendil-works/pi-coding-agent`](https://www.npmjs.com/package/@earendil-works/pi-coding-agent) and [`@earendil-works/pi-ai`](https://www.npmjs.com/package/@earendil-works/pi-ai) where needed.
 
 See [Upstream Pi attribution](docs/upstream-pi-attribution.md) for source links and the runtime ownership boundary.
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -99,7 +99,7 @@ One `.claude/settings.json` commit replaces per-member setup instructions.
 
 ## Pi Package Distribution
 
-Pi package sources generally support npm, git, and local paths. Pi itself is maintained upstream at [pi.dev](https://pi.dev) and [badlogic/pi-mono](https://github.com/badlogic/pi-mono). The packages in this repository are agentic-config packages that install into upstream Pi; they do not define the Pi CLI or core runtime. See [Upstream Pi attribution](upstream-pi-attribution.md) for the source links and package ownership boundary.
+Pi package sources generally support npm, git, and local paths. Pi itself is maintained upstream at [pi.dev](https://pi.dev) and [earendil-works/pi](https://github.com/earendil-works/pi). The packages in this repository are agentic-config packages that install into upstream Pi; they do not define the Pi CLI or core runtime. See [Upstream Pi attribution](upstream-pi-attribution.md) for the source links and package ownership boundary.
 
 For the current `agentic-config` monorepo package layout:
 - git-tag installs of the validated root umbrella package are the primary team and automation path

--- a/docs/upstream-pi-attribution.md
+++ b/docs/upstream-pi-attribution.md
@@ -7,11 +7,11 @@ agentic-config ships third-party Pi packages, skills, and extensions. Pi itself 
 | Surface | Reference | License |
 |---------|-----------|---------|
 | Pi project website | <https://pi.dev> | MIT for the public upstream packages referenced here |
-| Pi monorepo | <https://github.com/badlogic/pi-mono> | MIT |
-| Pi coding agent npm package | <https://www.npmjs.com/package/@mariozechner/pi-coding-agent> | MIT |
-| Pi coding agent source package | <https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent> | MIT |
-| Pi AI npm package | <https://www.npmjs.com/package/@mariozechner/pi-ai> | MIT |
-| Pi AI source package | <https://github.com/badlogic/pi-mono/tree/main/packages/ai> | MIT |
+| Pi monorepo | <https://github.com/earendil-works/pi> | MIT |
+| Pi coding agent npm package | <https://www.npmjs.com/package/@earendil-works/pi-coding-agent> | MIT |
+| Pi coding agent source package | <https://github.com/earendil-works/pi/tree/main/packages/coding-agent> | MIT |
+| Pi AI npm package | <https://www.npmjs.com/package/@earendil-works/pi-ai> | MIT |
+| Pi AI source package | <https://github.com/earendil-works/pi/tree/main/packages/ai> | MIT |
 
 The upstream package names are listed as their public npm identifiers because agentic-config imports those packages directly in its Pi extension packages. The MIT license entries above are taken from the public package metadata for the referenced upstream packages.
 
@@ -38,8 +38,8 @@ If this repository starts copying or bundling upstream Pi source files or assets
 
 The current package set imports upstream Pi APIs directly from:
 
-- `@mariozechner/pi-coding-agent`
-- `@mariozechner/pi-ai`
+- `@earendil-works/pi-coding-agent`
+- `@earendil-works/pi-ai`
 
 Those direct imports are currently used by `@agentic-config/pi-ac-tools` and `@agentic-config/pi-ac-workflow`. Other package roots install into Pi through package manifests, skills, bundled assets, and shared compatibility wiring.
 
@@ -49,4 +49,4 @@ When documenting Pi support in this repository:
 
 - Attribute Pi runtime behavior to upstream Pi and link to this page when the distinction matters.
 - Attribute `@agentic-config/pi-*`, `pimux`, `hook-compat`, generated skills, and workflow wrappers to agentic-config.
-- Avoid wording that suggests agentic-config owns the Pi CLI, Pi monorepo, or upstream `@mariozechner/*` packages.
+- Avoid wording that suggests agentic-config owns the Pi CLI, Pi monorepo, or upstream `@earendil-works/*` packages.

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,18 +111,18 @@
         "@agentic-config/pi-compat": "0.3.0"
       },
       "peerDependencies": {
-        "@mariozechner/pi-ai": "*",
-        "@mariozechner/pi-coding-agent": "*",
-        "@sinclair/typebox": "*"
+        "@earendil-works/pi-ai": "*",
+        "@earendil-works/pi-coding-agent": "*",
+        "typebox": "*"
       },
       "peerDependenciesMeta": {
-        "@mariozechner/pi-ai": {
+        "@earendil-works/pi-ai": {
           "optional": true
         },
-        "@mariozechner/pi-coding-agent": {
+        "@earendil-works/pi-coding-agent": {
           "optional": true
         },
-        "@sinclair/typebox": {
+        "typebox": {
           "optional": true
         }
       }
@@ -132,18 +132,18 @@
       "version": "0.3.0-alpha",
       "license": "MIT",
       "peerDependencies": {
-        "@mariozechner/pi-ai": "*",
-        "@mariozechner/pi-coding-agent": "*",
-        "@sinclair/typebox": "*"
+        "@earendil-works/pi-ai": "*",
+        "@earendil-works/pi-coding-agent": "*",
+        "typebox": "*"
       },
       "peerDependenciesMeta": {
-        "@mariozechner/pi-ai": {
+        "@earendil-works/pi-ai": {
           "optional": true
         },
-        "@mariozechner/pi-coding-agent": {
+        "@earendil-works/pi-coding-agent": {
           "optional": true
         },
-        "@sinclair/typebox": {
+        "typebox": {
           "optional": true
         }
       }

--- a/packages/README.md
+++ b/packages/README.md
@@ -4,12 +4,12 @@ This directory contains the current pi package surface for `agentic-config`.
 
 ## Upstream Pi dependency and attribution
 
-Pi is maintained upstream at [pi.dev](https://pi.dev) and [badlogic/pi-mono](https://github.com/badlogic/pi-mono). The packages in this directory are third-party agentic-config packages that install into upstream Pi through `pi install`.
+Pi is maintained upstream at [pi.dev](https://pi.dev) and [earendil-works/pi](https://github.com/earendil-works/pi). The packages in this directory are third-party agentic-config packages that install into upstream Pi through `pi install`.
 
 Direct upstream API imports currently use:
 
-- [`@mariozechner/pi-coding-agent`](https://www.npmjs.com/package/@mariozechner/pi-coding-agent), with source under [`packages/coding-agent`](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent)
-- [`@mariozechner/pi-ai`](https://www.npmjs.com/package/@mariozechner/pi-ai), with source under [`packages/ai`](https://github.com/badlogic/pi-mono/tree/main/packages/ai)
+- [`@earendil-works/pi-coding-agent`](https://www.npmjs.com/package/@earendil-works/pi-coding-agent), with source under [`packages/coding-agent`](https://github.com/earendil-works/pi/tree/main/packages/coding-agent)
+- [`@earendil-works/pi-ai`](https://www.npmjs.com/package/@earendil-works/pi-ai), with source under [`packages/ai`](https://github.com/earendil-works/pi/tree/main/packages/ai)
 
 See [docs/upstream-pi-attribution.md](../docs/upstream-pi-attribution.md) for the ownership boundary. In short: upstream Pi owns the CLI, package loader, extension API, and core runtime; agentic-config owns the `@agentic-config/pi-*` packages, generated skills, compatibility layers, package-local extensions, and `pimux` workflow runtime shipped here.
 

--- a/packages/pi-ac-tools/README.md
+++ b/packages/pi-ac-tools/README.md
@@ -29,7 +29,7 @@
 
 ## Upstream Pi attribution
 
-This package installs into upstream Pi and uses upstream Pi APIs for its package-local extensions. Direct imports include [`@mariozechner/pi-coding-agent`](https://www.npmjs.com/package/@mariozechner/pi-coding-agent) and [`@mariozechner/pi-ai`](https://www.npmjs.com/package/@mariozechner/pi-ai), whose source lives in [badlogic/pi-mono](https://github.com/badlogic/pi-mono).
+This package installs into upstream Pi and uses upstream Pi APIs for its package-local extensions. Direct imports include [`@earendil-works/pi-coding-agent`](https://www.npmjs.com/package/@earendil-works/pi-coding-agent) and [`@earendil-works/pi-ai`](https://www.npmjs.com/package/@earendil-works/pi-ai), whose source lives in [earendil-works/pi](https://github.com/earendil-works/pi).
 
 The `say` and `web-search` extensions are agentic-config package extensions. They are not upstream Pi features. See [Upstream Pi attribution](../../docs/upstream-pi-attribution.md) for the full boundary.
 

--- a/packages/pi-ac-tools/extensions/say.ts
+++ b/packages/pi-ac-tools/extensions/say.ts
@@ -1,8 +1,8 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 
-import { getAgentDir, type ExtensionAPI, type ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { Type } from "@sinclair/typebox";
+import { getAgentDir, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
 
 type AutoMode = "off" | "always" | "long";
 

--- a/packages/pi-ac-tools/extensions/web-search/adapters/brave.ts
+++ b/packages/pi-ac-tools/extensions/web-search/adapters/brave.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { resolveBraveApiKey, missingBraveKeySetupHint } from "../auth.js";
 import { AdapterUnavailableError, BackendExecutionError, ParseError, formatErrorMessage } from "../errors.js";
 import { normalizeResultShape } from "../normalize.js";

--- a/packages/pi-ac-tools/extensions/web-search/adapters/claude.ts
+++ b/packages/pi-ac-tools/extensions/web-search/adapters/claude.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { AdapterUnavailableError, BackendExecutionError, ParseError, formatErrorMessage } from "../errors.js";
 import { normalizeResultShape, parseJsonObjectFromText, stripAnsi, truncateText } from "../normalize.js";
 import { buildDelegatePrompt } from "../prompt-builders.js";

--- a/packages/pi-ac-tools/extensions/web-search/adapters/codex.ts
+++ b/packages/pi-ac-tools/extensions/web-search/adapters/codex.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { AdapterUnavailableError, BackendExecutionError, ParseError, formatErrorMessage } from "../errors.js";
 import { normalizeResultShape, parseJsonObjectFromText, stripAnsi, truncateText } from "../normalize.js";
 import { buildDelegatePrompt } from "../prompt-builders.js";

--- a/packages/pi-ac-tools/extensions/web-search/auth.ts
+++ b/packages/pi-ac-tools/extensions/web-search/auth.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
-import { AuthStorage, getAgentDir } from "@mariozechner/pi-coding-agent";
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { AuthStorage, getAgentDir } from "@earendil-works/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { RuntimeState } from "./types.js";
 
 export const BRAVE_AUTH_PROVIDER = "web-search-brave";

--- a/packages/pi-ac-tools/extensions/web-search/index.ts
+++ b/packages/pi-ac-tools/extensions/web-search/index.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import {
   BRAVE_AUTH_PATH,
   BRAVE_AUTH_PROVIDER,

--- a/packages/pi-ac-tools/extensions/web-search/lock-mode.ts
+++ b/packages/pi-ac-tools/extensions/web-search/lock-mode.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { LockState, RuntimeState } from "./types.js";
 
 const LOCK_ENTRY_TYPE = "web-search-lock";

--- a/packages/pi-ac-tools/extensions/web-search/orchestrator.ts
+++ b/packages/pi-ac-tools/extensions/web-search/orchestrator.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { getBraveAuthStatus } from "./auth.js";
 import { AdapterUnavailableError, formatErrorMessage } from "./errors.js";
 import { loadDefaultBackend } from "./preferences.js";

--- a/packages/pi-ac-tools/extensions/web-search/schema.ts
+++ b/packages/pi-ac-tools/extensions/web-search/schema.ts
@@ -1,5 +1,5 @@
-import { StringEnum } from "@mariozechner/pi-ai";
-import { Type } from "@sinclair/typebox";
+import { StringEnum } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
 
 export const LocationSchema = Type.Object(
   {

--- a/packages/pi-ac-tools/extensions/web-search/status.ts
+++ b/packages/pi-ac-tools/extensions/web-search/status.ts
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { formatBraveAuthStatus, getBraveAuthStatus } from "./auth.js";
 import { BRAVE_MONTHLY_LIMIT, getBackendAttemptOrder } from "./types.js";
 import type { RuntimeState } from "./types.js";

--- a/packages/pi-ac-tools/extensions/web-search/tool.ts
+++ b/packages/pi-ac-tools/extensions/web-search/tool.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { WebSearchToolSchema } from "./schema.js";
 import { applyDefaultsAndValidate } from "./request.js";
 import { executeWebSearch } from "./orchestrator.js";

--- a/packages/pi-ac-tools/extensions/web-search/types.ts
+++ b/packages/pi-ac-tools/extensions/web-search/types.ts
@@ -1,4 +1,4 @@
-import type { AuthStorage } from "@mariozechner/pi-coding-agent";
+import type { AuthStorage } from "@earendil-works/pi-coding-agent";
 
 export const BACKEND_NAMES = ["brave-search", "codex-search", "claude-search"] as const;
 export type BackendName = (typeof BACKEND_NAMES)[number];

--- a/packages/pi-ac-tools/package.json
+++ b/packages/pi-ac-tools/package.json
@@ -23,18 +23,18 @@
   ],
   "type": "module",
   "peerDependencies": {
-    "@mariozechner/pi-ai": "*",
-    "@mariozechner/pi-coding-agent": "*",
-    "@sinclair/typebox": "*"
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "typebox": "*"
   },
   "peerDependenciesMeta": {
-    "@mariozechner/pi-ai": {
+    "@earendil-works/pi-ai": {
       "optional": true
     },
-    "@mariozechner/pi-coding-agent": {
+    "@earendil-works/pi-coding-agent": {
       "optional": true
     },
-    "@sinclair/typebox": {
+    "typebox": {
       "optional": true
     }
   },

--- a/packages/pi-ac-workflow/README.md
+++ b/packages/pi-ac-workflow/README.md
@@ -19,7 +19,7 @@
 
 ## Upstream Pi attribution
 
-This package installs into upstream Pi and uses upstream Pi APIs for its package-local runtime extensions. Direct imports include [`@mariozechner/pi-coding-agent`](https://www.npmjs.com/package/@mariozechner/pi-coding-agent) and [`@mariozechner/pi-ai`](https://www.npmjs.com/package/@mariozechner/pi-ai), whose source lives in [badlogic/pi-mono](https://github.com/badlogic/pi-mono).
+This package installs into upstream Pi and uses upstream Pi APIs for its package-local runtime extensions. Direct imports include [`@earendil-works/pi-coding-agent`](https://www.npmjs.com/package/@earendil-works/pi-coding-agent) and [`@earendil-works/pi-ai`](https://www.npmjs.com/package/@earendil-works/pi-ai), whose source lives in [earendil-works/pi](https://github.com/earendil-works/pi).
 
 `pimux`, `strict-mux-runtime`, and the `ac-workflow-*` wrappers are agentic-config package surfaces. They are not upstream Pi features. See [Upstream Pi attribution](../../docs/upstream-pi-attribution.md) for the full boundary.
 

--- a/packages/pi-ac-workflow/extensions/pimux/index.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/index.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { promises as fs, watch as watchFs } from "node:fs";
 import type { FSWatcher } from "node:fs";
 import * as path from "node:path";
-import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
 	appendBridgeEvent,
 	appendBridgeEventIfMissing,

--- a/packages/pi-ac-workflow/extensions/pimux/schema.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/schema.ts
@@ -1,5 +1,5 @@
-import { StringEnum } from "@mariozechner/pi-ai";
-import { Type } from "@sinclair/typebox";
+import { StringEnum } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
 import { THINKING_EFFORT_LEVELS } from "./paths.ts";
 
 export const PIMUX_PARAMS = Type.Object({

--- a/packages/pi-ac-workflow/package.json
+++ b/packages/pi-ac-workflow/package.json
@@ -22,18 +22,18 @@
   ],
   "type": "module",
   "peerDependencies": {
-    "@mariozechner/pi-ai": "*",
-    "@mariozechner/pi-coding-agent": "*",
-    "@sinclair/typebox": "*"
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "typebox": "*"
   },
   "peerDependenciesMeta": {
-    "@mariozechner/pi-ai": {
+    "@earendil-works/pi-ai": {
       "optional": true
     },
-    "@mariozechner/pi-coding-agent": {
+    "@earendil-works/pi-coding-agent": {
       "optional": true
     },
-    "@sinclair/typebox": {
+    "typebox": {
       "optional": true
     }
   },

--- a/packages/pi-all/README.md
+++ b/packages/pi-all/README.md
@@ -8,7 +8,7 @@
 
 ## Upstream Pi attribution
 
-This package aggregates agentic-config packages that install into upstream Pi. It does not provide or replace the upstream Pi CLI, package loader, extension API, or core runtime. See [Upstream Pi attribution](../../docs/upstream-pi-attribution.md) for links to [pi.dev](https://pi.dev), [badlogic/pi-mono](https://github.com/badlogic/pi-mono), and the upstream npm packages used by this repository.
+This package aggregates agentic-config packages that install into upstream Pi. It does not provide or replace the upstream Pi CLI, package loader, extension API, or core runtime. See [Upstream Pi attribution](../../docs/upstream-pi-attribution.md) for links to [pi.dev](https://pi.dev), [earendil-works/pi](https://github.com/earendil-works/pi), and the upstream npm packages used by this repository.
 
 ## What this package aggregates today
 `@agentic-config/pi-all` is the one-shot install surface for the current shipped pi package set.

--- a/packages/pi-compat/README.md
+++ b/packages/pi-compat/README.md
@@ -7,7 +7,7 @@
 
 ## Upstream Pi attribution
 
-This package provides agentic-config compatibility helpers for packages that install into upstream Pi. It is not an upstream Pi package. Upstream Pi is referenced at [pi.dev](https://pi.dev), [badlogic/pi-mono](https://github.com/badlogic/pi-mono), and the public npm packages such as [`@mariozechner/pi-coding-agent`](https://www.npmjs.com/package/@mariozechner/pi-coding-agent).
+This package provides agentic-config compatibility helpers for packages that install into upstream Pi. It is not an upstream Pi package. Upstream Pi is referenced at [pi.dev](https://pi.dev), [earendil-works/pi](https://github.com/earendil-works/pi), and the public npm packages such as [`@earendil-works/pi-coding-agent`](https://www.npmjs.com/package/@earendil-works/pi-coding-agent).
 
 See [Upstream Pi attribution](../../docs/upstream-pi-attribution.md) for the ownership boundary between upstream Pi runtime behavior and agentic-config package behavior.
 


### PR DESCRIPTION
## Summary

Updates repo-owned Pi resources for the upstream scope migration to `@earendil-works/*` and current `typebox` imports.

### Key Changes

**Pi extensions/packages:**
- Replaced `@mariozechner/*` imports and peer deps with `@earendil-works/*`.
- Replaced `@sinclair/typebox` imports and peer deps with `typebox`.

**Docs:**
- Updated upstream Pi attribution links to `earendil-works/pi` and current npm package names.
- Added an Unreleased changelog entry.

## Test Plan

- [x] `node -v` -> `v22.19.0`
- [x] `pi --version` -> `0.80.2`
- [x] `pi list`
- [x] `rg -n "@mariozechner|badlogic/pi-mono|@sinclair/typebox" README.md docs packages .pi package-lock.json --glob '!**/node_modules/**'`
- [x] JSON parse package manifests and lockfile
- [x] Pre-commit PII audit passed

## Files Changed

**Pi extension/package refs:**
- `packages/pi-ac-tools/**`
- `packages/pi-ac-workflow/**`
- `.pi/extensions/**`
- `.pi/archive/extensions/**`
- `package-lock.json`

**Docs:**
- `README.md`
- `docs/upstream-pi-attribution.md`
- `docs/distribution.md`
- `packages/**/README.md`
- `CHANGELOG.md`

## Related

- **Spec repo branch**: `pi/update-base-pkg`
- **Spec commit**: `857dc63`

Generated with pi