### PR TITLE
fix(pimux): dedupe terminal delivery and preserve TTY rendering

### DIFF
--- a/packages/pi-ac-workflow/extensions/pimux/bridge.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/bridge.ts
@@ -76,6 +76,9 @@ export interface BridgeEvent {
 export interface BridgeParentState {
 	deliveredEventIds: string[];
 	terminalEventId?: string;
+	terminalDeliveryKey?: string;
+	terminalAgentId?: string;
+	terminalReportPath?: string;
 	terminalFinalizedAt?: string;
 	terminalObservedAt?: string;
 	terminalState?: BridgeSettlementState;
@@ -169,6 +172,9 @@ function mergeBridgeParentState(current: BridgeParentState, next: BridgeParentSt
 		...next,
 		deliveredEventIds: uniqueStrings([...(current.deliveredEventIds ?? []), ...(next.deliveredEventIds ?? [])]).slice(-500),
 		terminalEventId: next.terminalEventId ?? current.terminalEventId,
+		terminalDeliveryKey: next.terminalDeliveryKey ?? current.terminalDeliveryKey,
+		terminalAgentId: next.terminalAgentId ?? current.terminalAgentId,
+		terminalReportPath: next.terminalReportPath ?? current.terminalReportPath,
 		terminalFinalizedAt: preferLatestIso(current.terminalFinalizedAt, next.terminalFinalizedAt),
 		terminalObservedAt: preferLatestIso(current.terminalObservedAt, next.terminalObservedAt),
 		terminalState: preferTerminalState(current.terminalState, next.terminalState),

--- a/packages/pi-ac-workflow/extensions/pimux/docs/commands.md
+++ b/packages/pi-ac-workflow/extensions/pimux/docs/commands.md
@@ -81,7 +81,7 @@ Valid `report_parent` kinds:
 
 Parent-side interface delivery should also show parent -> child bridge messages as concise pimux events without triggering an extra turn. Use `send_message` for child-requested answers or user-directed instructions, not hurry-up nudges.
 
-After a terminal `report_parent`, pimux first records `terminal_report_received`, finalizes the managed session, then reports a settled state only after exit evidence exists. If exit evidence does not arrive before timeout, status/activity surface `terminal_report_exit_timeout` with recovery guidance. Terminal settlement notifications remain retryable until the parent delivery queue records delivery.
+After a terminal `report_parent`, pimux first records `terminal_report_received`, finalizes the managed session, then reports a settled state only after exit evidence exists. If exit evidence does not arrive before timeout, status/activity surface `terminal_report_exit_timeout` with recovery guidance. Terminal settlement notifications remain retryable until the parent delivery queue records delivery, then the terminal identity is idempotently suppressed on later scans. Prune and bridge-directory cleanup drop stale queued terminal deliveries rather than routing them to the parent again.
 
 If a new `spawn` is attempted while terminal settlement verification is pending, pimux fails closed with an explicit `Spawn suppressed` result that names the pending related child instead of creating an ambiguous second child.
 
@@ -100,7 +100,7 @@ If a new `spawn` is attempted while terminal settlement verification is pending,
 - interactive `open`, `capture`, `send`, and `kill` pickers should prefer live agents when no target is provided
 - `prune --dry-run` to preview historical cleanup candidates
 
-Auto-prune removes `terminated` or `missing` pimux registry entries aged at least `1d`; pending terminal-report states are retained for recovery.
+Auto-prune removes `terminated` or `missing` pimux registry entries aged at least `1d`; pending terminal-report states are retained for recovery. Manual or auto prune also invalidates parent-delivery queue entries and bridge watchers for pruned agents, so stale terminal events from removed bridges are not re-emitted.
 
 ## Control-plane recovery
 

--- a/packages/pi-ac-workflow/extensions/pimux/docs/protocol.md
+++ b/packages/pi-ac-workflow/extensions/pimux/docs/protocol.md
@@ -35,7 +35,7 @@ Implications:
 After a terminal child report, the pimux runtime finalizes the managed session promptly instead of leaving the child alive in an ambiguous post-closeout state.
 The child should not keep chatting or continue work after emitting a terminal report.
 `terminal_report_received` and `terminal_report_exit_timeout` are not settled success states; supervisors must wait for exit evidence or recover explicitly.
-Terminal settlement notification is durable parent-delivery work: bursty terminal reports may be batched, and a terminal notification remains retryable until the parent delivery queue records delivery metadata for that bridge.
+Terminal settlement notification is durable parent-delivery work: bursty terminal reports may be batched, and a terminal notification remains retryable until the parent delivery queue records delivery metadata for that bridge. Delivered terminal identities are idempotent: the same child `agentId` + settled state + terminal event id is surfaced to the parent at most once, and prune or bridge cleanup invalidates stale queued terminal deliveries instead of re-emitting them as fresh parent input.
 
 ## Nested orchestrator rule
 

--- a/packages/pi-ac-workflow/extensions/pimux/index.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/index.ts
@@ -95,6 +95,7 @@ import {
 	type ResolvedStatus,
 } from "./registry.ts";
 import {
+	buildTerminalDeliveryKey,
 	flushQueuedParentDeliveries,
 	hasDeliveredTerminalNotification,
 	shouldNotifyInactivityWatchdog,
@@ -112,6 +113,7 @@ import {
 	getAgentLauncherPath,
 	getAgentManifestPath,
 	getAgentPromptPath,
+	getBridgeLaunchPath,
 	getBridgeSignalsDir,
 	getCurrentEnv,
 	getStateRoot,
@@ -565,6 +567,16 @@ async function ensureDirectoryExists(targetCwd: string): Promise<void> {
 	if (!stat || !stat.isDirectory()) {
 		throw new Error(`Directory not found: ${resolved}`);
 	}
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+	const stat = await fs.stat(filePath).catch(() => undefined);
+	return Boolean(stat?.isFile());
+}
+
+async function bridgeRuntimeExists(bridgeDir: string): Promise<boolean> {
+	const stat = await fs.stat(bridgeDir).catch(() => undefined);
+	return Boolean(stat?.isDirectory()) && (await fileExists(getBridgeLaunchPath(bridgeDir)));
 }
 
 async function listManagedAgents(
@@ -1125,6 +1137,7 @@ function formatPruneResultLines(result: {
 async function runPruneCommand(
 	ctx: ExtensionCommandContext,
 	options: { scope?: AgentScope; rootAgentId?: string; olderThan?: string; dryRun?: boolean } = {},
+	onPruned?: (statuses: ResolvedStatus[]) => void,
 ): Promise<void> {
 	const dryRun = options.dryRun ?? false;
 	const preview = await pruneManagedAgents(ctx, { ...options, dryRun: true, mode: "manual" });
@@ -1141,6 +1154,7 @@ async function runPruneCommand(
 		}
 	}
 	const result = await pruneManagedAgents(ctx, { ...options, dryRun: false, mode: "manual" });
+	onPruned?.(result.pruned);
 	await presentText(ctx, "pimux prune", formatPruneResultLines(result));
 }
 
@@ -1345,6 +1359,56 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 	let explicitChildInspectionRequested = false;
 	let explicitChildInstructionRequested = false;
 	let explicitChildProbeRequested = false;
+	const queuedTerminalDeliveryKeys = new Set<string>();
+	const deliveredTerminalDeliveryKeys = new Set<string>();
+	const invalidatedBridgeDirs = new Set<string>();
+	const invalidatedAgentIds = new Set<string>();
+
+	const forgetQueuedTerminalDelivery = (delivery: QueuedParentDelivery): void => {
+		if (delivery.terminalDeliveryKey) queuedTerminalDeliveryKeys.delete(delivery.terminalDeliveryKey);
+	};
+
+	const removeQueuedParentDeliveries = (predicate: (delivery: QueuedParentDelivery) => boolean): void => {
+		for (const [key, delivery] of [...parentDeliveryQueue.entries()]) {
+			if (!predicate(delivery)) continue;
+			parentDeliveryQueue.delete(key);
+			forgetQueuedTerminalDelivery(delivery);
+		}
+	};
+
+	const rememberDeliveredTerminalDeliveries = (deliveries: QueuedParentDelivery[]): void => {
+		for (const delivery of deliveries) {
+			if (!delivery.terminalDeliveryKey) continue;
+			queuedTerminalDeliveryKeys.delete(delivery.terminalDeliveryKey);
+			deliveredTerminalDeliveryKeys.add(delivery.terminalDeliveryKey);
+		}
+		while (deliveredTerminalDeliveryKeys.size > 1000) {
+			const oldest = deliveredTerminalDeliveryKeys.values().next().value;
+			if (typeof oldest !== "string") break;
+			deliveredTerminalDeliveryKeys.delete(oldest);
+		}
+	};
+
+	const invalidateParentDeliveriesForBridge = (bridgeDir: string): void => {
+		invalidatedBridgeDirs.add(bridgeDir);
+		const watcher = parentBridgeWatchers.get(bridgeDir);
+		watcher?.close();
+		parentBridgeWatchers.delete(bridgeDir);
+		removeQueuedParentDeliveries((delivery) => delivery.bridgeDir === bridgeDir);
+	};
+
+	const invalidateParentDeliveriesForStatuses = (statuses: ResolvedStatus[]): void => {
+		for (const status of statuses) {
+			invalidatedAgentIds.add(status.record.agentId);
+			if (status.record.bridgeDir) invalidateParentDeliveriesForBridge(status.record.bridgeDir);
+		}
+		removeQueuedParentDeliveries((delivery) => invalidatedAgentIds.has(delivery.agentId ?? delivery.launch.agentId));
+	};
+
+	const isParentDeliveryInvalidated = (delivery: QueuedParentDelivery): boolean => {
+		return invalidatedBridgeDirs.has(delivery.bridgeDir)
+			|| invalidatedAgentIds.has(delivery.agentId ?? delivery.launch.agentId);
+	};
 
 	const persistNoPollingSupervision = (nextState: NoPollingSupervisionState): void => {
 		noPollingSupervision = nextState;
@@ -1417,7 +1481,11 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 			const parentState = await readBridgeParentState(delivery.bridgeDir).catch(() => ({ deliveredEventIds: [] }));
 			const timestamp = nowIso();
 			parentState.terminalEventId = delivery.terminalEventId;
+			parentState.terminalDeliveryKey = delivery.terminalDeliveryKey;
+			parentState.terminalAgentId = delivery.agentId ?? delivery.launch.agentId;
+			parentState.terminalReportPath = delivery.reportPath;
 			parentState.terminalState = delivery.settledState;
+			parentState.protocolViolationReason = delivery.protocolViolationReason ?? parentState.protocolViolationReason;
 			parentState.terminalNotificationBatchId = batchId;
 			if (phase === "queued") {
 				parentState.terminalNotificationQueuedAt = timestamp;
@@ -1452,6 +1520,7 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 			queue: parentDeliveryQueue,
 			makeBatchId: () => `pimux-batch-${randomUUID()}`,
 			updateTerminalNotificationState,
+			markTerminalDeliveriesSent: rememberDeliveredTerminalDeliveries,
 			markParentDeliveriesDelivered,
 			sendParentMessage: (batchId, deliveries) => {
 				pi.sendMessage(
@@ -1477,6 +1546,13 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 	};
 
 	const enqueueParentDelivery = (delivery: QueuedParentDelivery, ctx: ExtensionContext): void => {
+		if (isParentDeliveryInvalidated(delivery)) return;
+		if (delivery.terminalDeliveryKey) {
+			if (queuedTerminalDeliveryKeys.has(delivery.terminalDeliveryKey) || deliveredTerminalDeliveryKeys.has(delivery.terminalDeliveryKey)) return;
+			queuedTerminalDeliveryKeys.add(delivery.terminalDeliveryKey);
+		}
+		const previous = parentDeliveryQueue.get(delivery.key);
+		if (previous) forgetQueuedTerminalDelivery(previous);
 		parentDeliveryQueue.set(delivery.key, delivery);
 		if (parentDeliveryFlushTimer) return;
 		parentDeliveryFlushTimer = setTimeout(() => {
@@ -1540,6 +1616,11 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 	};
 
 	const processBridgeDeliveriesOnce = async (bridgeDir: string, sessionKey: string, ctx: ExtensionContext) => {
+		if (invalidatedBridgeDirs.has(bridgeDir)) return;
+		if (!(await bridgeRuntimeExists(bridgeDir))) {
+			invalidateParentDeliveriesForBridge(bridgeDir);
+			return;
+		}
 		const launch = await readBridgeLaunch(bridgeDir);
 		if (launch.parentSessionKey !== sessionKey) return;
 		let parentState = await readBridgeParentState(bridgeDir);
@@ -1606,64 +1687,92 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 		}
 		if (isSettledTerminalState(settlement.settledState)) {
 			const finalizedAt = parentState.terminalFinalizedAt ?? nowIso();
+			const terminalReportPath = settlement.terminalEvent?.reportPath;
+			const terminalDeliveryKey = buildTerminalDeliveryKey({
+				bridgeDir,
+				agentId: launch.agentId,
+				settledState: settlement.settledState,
+				terminalEventId: settlement.terminalEvent?.eventId,
+				reportPath: terminalReportPath,
+				protocolViolationReason: settlement.protocolViolationReason,
+			});
 			const alreadyObserved =
 				Boolean(parentState.terminalObservedAt) &&
 				parentState.terminalState === settlement.settledState &&
 				parentState.terminalEventId === settlement.terminalEvent?.eventId &&
 				parentState.protocolViolationReason === settlement.protocolViolationReason;
-			const notificationDelivered = hasDeliveredTerminalNotification(parentState, {
+			const notificationDelivered = deliveredTerminalDeliveryKeys.has(terminalDeliveryKey) || hasDeliveredTerminalNotification(parentState, {
+				terminalDeliveryKey,
+				terminalAgentId: launch.agentId,
+				terminalReportPath,
 				terminalState: settlement.settledState,
 				terminalEventId: settlement.terminalEvent?.eventId,
 				protocolViolationReason: settlement.protocolViolationReason,
 			});
+			if (notificationDelivered) {
+				deliveredTerminalDeliveryKeys.add(terminalDeliveryKey);
+				queuedTerminalDeliveryKeys.delete(terminalDeliveryKey);
+			}
 			if (!alreadyObserved) {
 				parentState.terminalState = settlement.settledState;
 				parentState.terminalEventId = settlement.terminalEvent?.eventId;
+				parentState.terminalDeliveryKey = terminalDeliveryKey;
+				parentState.terminalAgentId = launch.agentId;
+				parentState.terminalReportPath = terminalReportPath;
 				parentState.terminalFinalizedAt = finalizedAt;
 				parentState.terminalObservedAt = finalizedAt;
 				parentState.protocolViolationReason = settlement.protocolViolationReason;
 				changed = true;
 			}
 			if (!notificationDelivered) {
-				let content: string;
-				if (settlement.terminalEvent) {
-					content = await buildParentDeliveryContent(settlement.terminalEvent, launch, {
-						terminalEventId: settlement.terminalEvent.eventId,
-						finalizedAt,
-						settledState: settlement.settledState,
-						settlementReason: settlement.protocolViolationReason,
-					});
+				if (terminalReportPath && !(await fileExists(terminalReportPath))) {
+					deliveredTerminalDeliveryKeys.add(terminalDeliveryKey);
+					queuedTerminalDeliveryKeys.delete(terminalDeliveryKey);
 				} else {
-					content = buildProtocolViolationDeliveryContent(
-						launch,
-						finalizedAt,
-						settlement.protocolViolationReason ?? "Child exited without a valid terminal declaration.",
+					let content: string;
+					if (settlement.terminalEvent) {
+						content = await buildParentDeliveryContent(settlement.terminalEvent, launch, {
+							terminalEventId: settlement.terminalEvent.eventId,
+							finalizedAt,
+							settledState: settlement.settledState,
+							settlementReason: settlement.protocolViolationReason,
+						});
+					} else {
+						content = buildProtocolViolationDeliveryContent(
+							launch,
+							finalizedAt,
+							settlement.protocolViolationReason ?? "Child exited without a valid terminal declaration.",
+						);
+					}
+					enqueueParentDelivery(
+						{
+							key: terminalDeliveryKey,
+							bridgeDir,
+							launch,
+							content,
+							triggerTurn: shouldTriggerTurnForSettledState(settlement.settledState, launch),
+							eventIds: settlement.terminalEvent ? [settlement.terminalEvent.eventId] : [],
+							agentId: launch.agentId,
+							reportPath: terminalReportPath,
+							terminalDeliveryKey,
+							terminalEventId: settlement.terminalEvent?.eventId,
+							settledState: settlement.settledState,
+							protocolViolationReason: settlement.protocolViolationReason,
+							createdAt: finalizedAt,
+						},
+						ctx,
 					);
+					nextLock = updateControlPlaneLockForTerminalSettlement(nextLock, {
+						agentId: launch.agentId,
+						eventId: settlement.terminalEvent?.eventId,
+						timestamp: finalizedAt,
+					});
+					nextSupervision = updateNoPollingSupervisionForTerminalSettlement(nextSupervision, {
+						agentId: launch.agentId,
+						eventId: settlement.terminalEvent?.eventId,
+						timestamp: finalizedAt,
+					});
 				}
-				enqueueParentDelivery(
-					{
-						key: `settlement:${bridgeDir}:${settlement.terminalEvent?.eventId ?? settlement.settledState}`,
-						bridgeDir,
-						launch,
-						content,
-						triggerTurn: shouldTriggerTurnForSettledState(settlement.settledState, launch),
-						eventIds: settlement.terminalEvent ? [settlement.terminalEvent.eventId] : [],
-						terminalEventId: settlement.terminalEvent?.eventId,
-						settledState: settlement.settledState,
-						createdAt: finalizedAt,
-					},
-					ctx,
-				);
-				nextLock = updateControlPlaneLockForTerminalSettlement(nextLock, {
-					agentId: launch.agentId,
-					eventId: settlement.terminalEvent?.eventId,
-					timestamp: finalizedAt,
-				});
-				nextSupervision = updateNoPollingSupervisionForTerminalSettlement(nextSupervision, {
-					agentId: launch.agentId,
-					eventId: settlement.terminalEvent?.eventId,
-					timestamp: finalizedAt,
-				});
 			}
 		}
 		if (nextLock && nextLock !== currentLock) {
@@ -1699,7 +1808,12 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 	};
 
 	const subscribeParentBridge = async (bridgeDir: string, ctx: ExtensionContext) => {
+		if (invalidatedBridgeDirs.has(bridgeDir)) return;
 		if (parentBridgeWatchers.has(bridgeDir)) return;
+		if (!(await bridgeRuntimeExists(bridgeDir))) {
+			invalidateParentDeliveriesForBridge(bridgeDir);
+			return;
+		}
 		await fs.mkdir(getBridgeSignalsDir(bridgeDir), { recursive: true });
 		const watcher = watchFs(getBridgeSignalsDir(bridgeDir), { persistent: false }, () => {
 			runBackgroundTask(processBridgeDeliveries(bridgeDir, getSessionKey(ctx), ctx));
@@ -1710,6 +1824,11 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 	const reconcileParentBridgeWatchers = async (ctx: ExtensionContext) => {
 		const desired = new Set<string>();
 		for (const entry of getSessionBridgeEntries(ctx)) {
+			if (invalidatedBridgeDirs.has(entry.bridgeDir)) continue;
+			if (!(await bridgeRuntimeExists(entry.bridgeDir))) {
+				invalidateParentDeliveriesForBridge(entry.bridgeDir);
+				continue;
+			}
 			desired.add(entry.bridgeDir);
 			await subscribeParentBridge(entry.bridgeDir, ctx);
 			await processBridgeDeliveries(entry.bridgeDir, getSessionKey(ctx), ctx);
@@ -2211,7 +2330,7 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 					rootAgentId: getStringFlag(parsed, "root"),
 					olderThan: getStringFlag(parsed, "older-than"),
 					dryRun: hasFlag(parsed, "dry-run"),
-				});
+				}, invalidateParentDeliveriesForStatuses);
 				return;
 			}
 			case "unlock": {
@@ -2321,7 +2440,8 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 		await fs.mkdir(stateRoot, { recursive: true });
 		const currentEnv = getCurrentEnv();
 		if (!currentEnv.agentId) {
-			await pruneManagedAgents(ctx, { scope: "all", olderThan: "1d", dryRun: false, mode: "auto" });
+			const autoPruneResult = await pruneManagedAgents(ctx, { scope: "all", olderThan: "1d", dryRun: false, mode: "auto" });
+			invalidateParentDeliveriesForStatuses(autoPruneResult.pruned);
 		}
 		let shouldShutdownTerminatedAgent = false;
 		if (currentEnv.agentId) {
@@ -2560,6 +2680,7 @@ export default function pimuxExtension(pi: ExtensionAPI) {
 							dryRun: params.dryRun ?? false,
 							mode: "manual",
 						});
+						invalidateParentDeliveriesForStatuses(result.pruned);
 						return buildToolResult(formatPruneResultLines(result).join("\n"), {
 							action: params.action,
 							scope: result.scope,

--- a/packages/pi-ac-workflow/extensions/pimux/parent-delivery.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/parent-delivery.ts
@@ -9,19 +9,39 @@ export interface QueuedParentDelivery {
 	content: string;
 	triggerTurn: boolean;
 	eventIds: string[];
+	agentId?: string;
+	reportPath?: string;
+	terminalDeliveryKey?: string;
 	terminalEventId?: string;
 	settledState?: SettledTerminalState;
+	protocolViolationReason?: string;
 	createdAt: string;
 }
 
+export interface TerminalDeliveryIdentityInput {
+	bridgeDir: string;
+	agentId?: string;
+	settledState: SettledTerminalState;
+	terminalEventId?: string;
+	reportPath?: string;
+	protocolViolationReason?: string;
+}
+
 export interface TerminalNotificationState {
+	deliveredEventIds?: string[];
 	terminalNotificationDeliveredAt?: string;
+	terminalDeliveryKey?: string;
+	terminalAgentId?: string;
+	terminalReportPath?: string;
 	terminalState?: BridgeSettlementState;
 	terminalEventId?: string;
 	protocolViolationReason?: string;
 }
 
 export interface TerminalNotificationIdentity {
+	terminalDeliveryKey?: string;
+	terminalAgentId?: string;
+	terminalReportPath?: string;
 	terminalState: SettledTerminalState;
 	terminalEventId?: string;
 	protocolViolationReason?: string;
@@ -40,6 +60,7 @@ export interface ParentDeliveryFlushOptions<TDelivery extends QueuedParentDelive
 	makeBatchId: () => string;
 	updateTerminalNotificationState: (deliveries: TDelivery[], batchId: string, phase: "queued" | "delivered") => Promise<void>;
 	sendParentMessage: (batchId: string, deliveries: TDelivery[]) => void;
+	markTerminalDeliveriesSent?: (deliveries: TDelivery[]) => void;
 	markParentDeliveriesDelivered: (deliveries: TDelivery[]) => Promise<void>;
 	scheduleRetry: () => void;
 }
@@ -58,12 +79,40 @@ export function shouldSendStatusRequestProbe(
 		&& activity.activityState !== "missing_session";
 }
 
+function keyPart(value: string | undefined): string {
+	return encodeURIComponent(value?.trim() || "unknown");
+}
+
+export function buildTerminalDeliveryKey(identity: TerminalDeliveryIdentityInput): string {
+	if (identity.terminalEventId?.trim()) {
+		return [
+			"terminal",
+			identity.agentId?.trim() ? `agent=${keyPart(identity.agentId)}` : `bridge=${keyPart(identity.bridgeDir)}`,
+			`state=${keyPart(identity.settledState)}`,
+			`event=${keyPart(identity.terminalEventId)}`,
+		].join(":");
+	}
+	return [
+		"terminal",
+		`bridge=${keyPart(identity.bridgeDir)}`,
+		`agent=${keyPart(identity.agentId)}`,
+		`state=${keyPart(identity.settledState)}`,
+		`reason=${keyPart(identity.protocolViolationReason)}`,
+		`report=${keyPart(identity.reportPath)}`,
+	].join(":");
+}
+
 export function hasDeliveredTerminalNotification(
 	parentState: TerminalNotificationState,
 	identity: TerminalNotificationIdentity,
 ): boolean {
-	return Boolean(parentState.terminalNotificationDeliveredAt)
-		&& parentState.terminalState === identity.terminalState
+	const hasDeliveredMarker = Boolean(parentState.terminalNotificationDeliveredAt)
+		|| Boolean(identity.terminalEventId && parentState.deliveredEventIds?.includes(identity.terminalEventId));
+	if (!hasDeliveredMarker) return false;
+	if (identity.terminalDeliveryKey && parentState.terminalDeliveryKey) {
+		return parentState.terminalDeliveryKey === identity.terminalDeliveryKey;
+	}
+	return parentState.terminalState === identity.terminalState
 		&& parentState.terminalEventId === identity.terminalEventId
 		&& parentState.protocolViolationReason === identity.protocolViolationReason;
 }
@@ -83,15 +132,19 @@ export async function flushQueuedParentDeliveries<TDelivery extends QueuedParent
 	const deliveries = [...options.queue.values()].sort((left, right) => left.createdAt.localeCompare(right.createdAt) || left.key.localeCompare(right.key));
 	const batchId = options.makeBatchId();
 	options.queue.clear();
+	let sendCompleted = false;
 	try {
 		await options.updateTerminalNotificationState(deliveries, batchId, "queued");
 		options.sendParentMessage(batchId, deliveries);
+		sendCompleted = true;
+		options.markTerminalDeliveriesSent?.(deliveries);
 		await options.markParentDeliveriesDelivered(deliveries);
 		await options.updateTerminalNotificationState(deliveries, batchId, "delivered");
 		return { batchId, deliveries, sent: true };
 	} catch (error) {
-		for (const delivery of deliveries) options.queue.set(delivery.key, delivery);
-		options.scheduleRetry();
+		const retryableDeliveries = sendCompleted ? deliveries.filter((delivery) => !delivery.terminalDeliveryKey) : deliveries;
+		for (const delivery of retryableDeliveries) options.queue.set(delivery.key, delivery);
+		if (retryableDeliveries.length > 0) options.scheduleRetry();
 		throw error;
 	}
 }

--- a/packages/pi-ac-workflow/extensions/pimux/tmux.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/tmux.ts
@@ -274,8 +274,9 @@ PROMPT=$(cat ${shellQuote(params.promptPath)})
 PI_CMD=(${shellArray(commandParts)})
 PI_EXIT_CMD=(${shellArray(launcherExitCommandParts)})
 PI_LOG=${shellQuote(launcherLogPath)}
-"\${PI_CMD[@]}" "$PROMPT" 2>&1 | tee "$PI_LOG"
-status=\${PIPESTATUS[0]}
+export PI_TUI_WRITE_LOG="$PI_LOG"
+"\${PI_CMD[@]}" "$PROMPT" 2> >(tee -a "$PI_LOG" >&2)
+status=$?
 printf '\n[pi exited with status %s]\n' "$status"
 "\${PI_EXIT_CMD[@]}" --bridge-dir ${shellQuote(params.bridgeDir)} --exit-status "$status" --log-path "$PI_LOG" || true
 exit "$status"

--- a/tests/test_pimux_parent_delivery_behavior.py
+++ b/tests/test_pimux_parent_delivery_behavior.py
@@ -34,6 +34,10 @@ if (payload.action === "flush") {
         calls.push({ type: "send", batchId, keys: deliveries.map((delivery) => delivery.key) });
         if (payload.failSend) throw new Error("send failed");
       },
+      markTerminalDeliveriesSent: (deliveries) => {
+        const terminalDeliveryKeys = deliveries.map((delivery) => delivery.terminalDeliveryKey).filter(Boolean);
+        if (terminalDeliveryKeys.length > 0) calls.push({ type: "sent-terminal", terminalDeliveryKeys });
+      },
       markParentDeliveriesDelivered: async (deliveries) => {
         calls.push({ type: "mark", eventIds: deliveries.flatMap((delivery) => delivery.eventIds) });
         if (payload.failMark) throw new Error("mark failed");
@@ -49,6 +53,11 @@ if (payload.action === "flush") {
 
 if (payload.action === "terminal_notification") {
   writeJson(runtime.hasDeliveredTerminalNotification(payload.parentState, payload.identity));
+  process.exit(0);
+}
+
+if (payload.action === "terminal_key") {
+  writeJson(runtime.buildTerminalDeliveryKey(payload.input));
   process.exit(0);
 }
 
@@ -91,9 +100,17 @@ def run_runtime(payload: dict[str, Any]) -> Any:
     return json.loads(result.stdout)
 
 
-def delivery(key: str, *, event_ids: list[str] | None = None, created_at: str = "2026-04-17T10:00:00Z") -> dict[str, Any]:
+def delivery(
+    key: str,
+    *,
+    event_ids: list[str] | None = None,
+    created_at: str = "2026-04-17T10:00:00Z",
+    terminal_delivery_key: str | None = None,
+    settled_state: str | None = None,
+    terminal_event_id: str | None = None,
+) -> dict[str, Any]:
     """Build a synthetic queued parent delivery."""
-    return {
+    result: dict[str, Any] = {
         "key": key,
         "bridgeDir": f"/tmp/{key}",
         "launch": {"agentId": f"agent-{key}"},
@@ -102,6 +119,11 @@ def delivery(key: str, *, event_ids: list[str] | None = None, created_at: str = 
         "eventIds": event_ids or [f"evt-{key}"],
         "createdAt": created_at,
     }
+    if terminal_delivery_key:
+        result["terminalDeliveryKey"] = terminal_delivery_key
+        result["settledState"] = settled_state or "settled_failure"
+        result["terminalEventId"] = terminal_event_id or result["eventIds"][0]
+    return result
 
 
 def test_flush_requeues_deliveries_when_send_fails() -> None:
@@ -177,6 +199,96 @@ def test_terminal_notification_identity_prevents_duplicate_delivered_notificatio
             "identity": identity,
         }
     ) is False
+
+
+def test_terminal_delivery_key_prefers_child_terminal_event_identity() -> None:
+    """Stable terminal event ids should dedupe across bridge/report path churn for one child."""
+    base = {
+        "agentId": "child-a",
+        "settledState": "settled_failure",
+        "terminalEventId": "evt-terminal",
+        "bridgeDir": "/tmp/bridge-a",
+        "reportPath": "/tmp/bridge-a/reports/001-failure.md",
+    }
+    same_terminal = run_runtime(
+        {
+            "action": "terminal_key",
+            "input": {**base, "bridgeDir": "/tmp/removed-bridge", "reportPath": "/tmp/missing.md"},
+        }
+    )
+    assert run_runtime({"action": "terminal_key", "input": base}) == same_terminal
+    assert run_runtime({"action": "terminal_key", "input": {**base, "agentId": "child-b"}}) != same_terminal
+
+
+def test_terminal_notification_identity_can_use_delivery_key_or_delivered_event_id() -> None:
+    """Durable terminal keys and delivered event ids should both suppress late duplicates."""
+    identity = {
+        "terminalDeliveryKey": "terminal:agent=child-a:state=settled_failure:event=evt-terminal",
+        "terminalState": "settled_failure",
+        "terminalEventId": "evt-terminal",
+    }
+    assert run_runtime(
+        {
+            "action": "terminal_notification",
+            "parentState": {
+                "terminalNotificationDeliveredAt": "2026-04-17T10:05:00Z",
+                "terminalDeliveryKey": identity["terminalDeliveryKey"],
+            },
+            "identity": identity,
+        }
+    ) is True
+    assert run_runtime(
+        {
+            "action": "terminal_notification",
+            "parentState": {
+                "deliveredEventIds": ["evt-terminal"],
+                "terminalState": "settled_failure",
+                "terminalEventId": "evt-terminal",
+            },
+            "identity": identity,
+        }
+    ) is True
+    assert run_runtime(
+        {
+            "action": "terminal_notification",
+            "parentState": {
+                "terminalNotificationDeliveredAt": "2026-04-17T10:05:00Z",
+                "terminalDeliveryKey": identity["terminalDeliveryKey"],
+            },
+            "identity": {
+                "terminalDeliveryKey": "terminal:agent=recovery-child:state=settled_completion:event=evt-recovery",
+                "terminalState": "settled_completion",
+                "terminalEventId": "evt-recovery",
+            },
+        }
+    ) is False
+
+
+def test_flush_requeues_terminal_delivery_when_send_fails() -> None:
+    """Terminal dedupe must not suppress a delivery that was never sent."""
+    terminal = delivery(
+        "terminal-a",
+        terminal_delivery_key="terminal:agent=child-a:state=settled_failure:event=evt-terminal",
+        terminal_event_id="evt-terminal",
+    )
+    result = run_runtime({"action": "flush", "deliveries": [terminal], "failSend": True})
+    assert result["ok"] is False
+    assert result["queueKeys"] == ["terminal-a"]
+    assert [call["type"] for call in result["calls"]] == ["terminal", "send", "retry"]
+
+
+def test_flush_does_not_requeue_sent_terminal_delivery_when_ack_persistence_fails() -> None:
+    """Once parent send succeeds, terminal deliveries should not be resent because ack persistence failed."""
+    terminal = delivery(
+        "terminal-a",
+        terminal_delivery_key="terminal:agent=child-a:state=settled_failure:event=evt-terminal",
+        terminal_event_id="evt-terminal",
+    )
+    result = run_runtime({"action": "flush", "deliveries": [terminal], "failMark": True})
+    assert result["ok"] is False
+    assert result["queueKeys"] == []
+    assert [call["type"] for call in result["calls"]] == ["terminal", "send", "sent-terminal", "mark"]
+    assert result["calls"][2]["terminalDeliveryKeys"] == ["terminal:agent=child-a:state=settled_failure:event=evt-terminal"]
 
 
 def test_watchdog_notifies_once_per_quiet_window() -> None:

--- a/tests/test_pimux_runtime_surface.py
+++ b/tests/test_pimux_runtime_surface.py
@@ -261,8 +261,12 @@ def test_launcher_reports_startup_failures_and_exits_instead_of_dropping_to_a_sh
     assert '"--no-extensions"' in tmux_text
     assert '...params.extensionPaths.flatMap((extensionPath) => ["-e", extensionPath])' in tmux_text
     assert 'PI_EXIT_CMD=(' in tmux_text
-    assert 'tee "$PI_LOG"' in tmux_text
-    assert 'status=\\${PIPESTATUS[0]}' in tmux_text
+    assert 'export PI_TUI_WRITE_LOG="$PI_LOG"' in tmux_text
+    assert '2>&1 | tee "$PI_LOG"' not in tmux_text
+    assert 'tee "$PI_LOG"' not in tmux_text
+    assert 'PIPESTATUS' not in tmux_text
+    assert '"\\${PI_CMD[@]}" "$PROMPT" 2> >(tee -a "$PI_LOG" >&2)' in tmux_text
+    assert 'status=$?' in tmux_text
     assert '"\\${PI_EXIT_CMD[@]}" --bridge-dir' in tmux_text
     assert 'exit "$status"' in tmux_text
     assert 'exec "${SHELL:-/bin/bash}"' not in tmux_text

--- a/tests/test_pimux_runtime_surface.py
+++ b/tests/test_pimux_runtime_surface.py
@@ -35,7 +35,8 @@ def test_parent_runtime_batches_and_retries_terminal_delivery() -> None:
     assert "terminalNotificationDeliveredAt" in bridge_text
     assert "terminalNotificationAttemptCount" in bridge_text
     assert "!notificationDelivered" in index_text
-    assert "key: `settlement:${bridgeDir}:${settlement.terminalEvent?.eventId ?? settlement.settledState}`" in index_text
+    assert "key: terminalDeliveryKey" in index_text
+    assert "terminalDeliveryKey," in index_text
     assert "const processingParentBridges = new Map<string, ParentBridgeProcessingState>();" in index_text
     assert "existing.rerunRequested = true;" in index_text
 
@@ -52,13 +53,39 @@ def test_parent_delivery_ack_happens_after_successful_send() -> None:
     assert "enqueueParentDelivery(" in deliverable_block
     assert "delivered.add(event.eventId)" not in deliverable_block
     assert "await flushQueuedParentDeliveries({" in index_text
+    assert "markTerminalDeliveriesSent: rememberDeliveredTerminalDeliveries," in index_text
     assert "markParentDeliveriesDelivered," in index_text
     assert "sendParentMessage:" in index_text
+    assert "options.markTerminalDeliveriesSent?.(deliveries);" in parent_delivery_text
     assert "await options.markParentDeliveriesDelivered(deliveries);" in parent_delivery_text
     assert "await options.updateTerminalNotificationState(deliveries, batchId, \"delivered\");" in parent_delivery_text
+    assert "const retryableDeliveries = sendCompleted ? deliveries.filter((delivery) => !delivery.terminalDeliveryKey) : deliveries;" in parent_delivery_text
     assert "eventIds.push(...delivery.eventIds);" in index_text
     assert "parentState.deliveredEventIds = [...delivered].slice(-500);" in index_text
     assert "deliveredEventIds: uniqueStrings([...(current.deliveredEventIds ?? []), ...(next.deliveredEventIds ?? [])]).slice(-500)," in bridge_text
+
+
+def test_runtime_invalidates_stale_terminal_deliveries_after_prune_or_bridge_cleanup() -> None:
+    """Pruned/missing bridges should clear queued terminal deliveries instead of re-emitting them."""
+    index_text = PIMUX_INDEX.read_text()
+    parent_delivery_text = (PIMUX_PACKAGE_DIR / "parent-delivery.ts").read_text()
+    bridge_text = PIMUX_BRIDGE.read_text()
+    assert "const queuedTerminalDeliveryKeys = new Set<string>();" in index_text
+    assert "const deliveredTerminalDeliveryKeys = new Set<string>();" in index_text
+    assert "const invalidatedBridgeDirs = new Set<string>();" in index_text
+    assert "const invalidatedAgentIds = new Set<string>();" in index_text
+    assert "const invalidateParentDeliveriesForBridge = (bridgeDir: string): void => {" in index_text
+    assert "watcher?.close();" in index_text
+    assert "removeQueuedParentDeliveries((delivery) => delivery.bridgeDir === bridgeDir);" in index_text
+    assert "const invalidateParentDeliveriesForStatuses = (statuses: ResolvedStatus[]): void => {" in index_text
+    assert "invalidatedAgentIds.add(status.record.agentId);" in index_text
+    assert "if (!(await bridgeRuntimeExists(entry.bridgeDir))) {" in index_text
+    assert "invalidateParentDeliveriesForBridge(entry.bridgeDir);" in index_text
+    assert "if (terminalReportPath && !(await fileExists(terminalReportPath))) {" in index_text
+    assert "buildTerminalDeliveryKey" in parent_delivery_text
+    assert "terminalDeliveryKey?: string;" in bridge_text
+    assert "terminalAgentId?: string;" in bridge_text
+    assert "terminalReportPath?: string;" in bridge_text
 
 
 def test_activity_and_ping_agent_surface_is_available() -> None:


### PR DESCRIPTION
## Summary

Fixes pimux terminal delivery idempotence so stale child settlement events are not re-emitted after delivery, prune, or bridge cleanup. Also includes the existing follow-up fix that preserves child Pi TTY rendering by avoiding stdout piping through `tee`.

- Adds stable terminal delivery identity keys and persisted terminal metadata.
- Suppresses duplicate queued/sent terminal deliveries and invalidates stale deliveries on prune or missing bridge runtime.
- Preserves child Pi stdout on the tmux pane while still logging stderr and exit evidence.

### Root Cause

Terminal settlement notifications were keyed mostly by bridge/event queue state and could be re-enqueued by later scans if bridge/session state was stale or cleanup had removed reports. Separately, launcher stdout piping through `tee` could make child Pi run without the expected interactive TTY rendering behavior.

### Key Changes

**Terminal Delivery Dedupe:**
- Added terminal delivery keys in `parent-delivery.ts` using child agent, settled state, and terminal event id.
- Persisted terminal delivery metadata in bridge parent state.
- Added in-memory queued/sent terminal key tracking so repeat scans do not resend handled terminal events.

**Prune and Stale Bridge Handling:**
- Invalidates queued parent deliveries and closes bridge watchers for pruned agents.
- Treats missing bridge runtime metadata as stale instead of recreating `.signals` and reprocessing removed bridges.
- Suppresses stale terminal deliveries when referenced terminal report paths are gone.

**Child TTY Rendering:**
- Keeps child Pi stdout attached to the tmux pane.
- Uses `PI_TUI_WRITE_LOG` plus stderr teeing for logging without breaking the interactive TUI path.

## Test Plan

- [x] `uv run pytest tests/test_pimux_parent_delivery_behavior.py tests/test_pimux_runtime_surface.py tests/test_pimux_prune_navigation.py tests/test_pimux_registry.py -q`
- [x] `uv run ruff check --fix tests/test_pimux_parent_delivery_behavior.py tests/test_pimux_runtime_surface.py tests/test_pimux_prune_navigation.py tests/test_pimux_registry.py`
- [x] `uv run pyright tests/test_pimux_parent_delivery_behavior.py tests/test_pimux_runtime_surface.py tests/test_pimux_prune_navigation.py tests/test_pimux_registry.py`
- [x] `node --experimental-strip-types --check packages/pi-ac-workflow/extensions/pimux/index.ts`
- [x] `node --experimental-strip-types --check packages/pi-ac-workflow/extensions/pimux/parent-delivery.ts`
- [x] `node --experimental-strip-types --check packages/pi-ac-workflow/extensions/pimux/bridge.ts`
- [x] `node --experimental-strip-types --check packages/pi-ac-workflow/extensions/pimux/tmux.ts`

## Files Changed

**Core Runtime:**
- `packages/pi-ac-workflow/extensions/pimux/index.ts` - Adds terminal delivery dedupe, stale bridge invalidation, prune cleanup, and missing report fail-closed handling.
- `packages/pi-ac-workflow/extensions/pimux/parent-delivery.ts` - Adds terminal delivery identity helpers and retry-safe sent terminal handling.
- `packages/pi-ac-workflow/extensions/pimux/bridge.ts` - Persists terminal delivery metadata in bridge parent state.
- `packages/pi-ac-workflow/extensions/pimux/tmux.ts` - Preserves child Pi stdout TTY rendering while maintaining logging and exit handling.

**Tests:**
- `tests/test_pimux_parent_delivery_behavior.py` - Covers terminal key stability, duplicate suppression, retry semantics, and sent-terminal ack behavior.
- `tests/test_pimux_runtime_surface.py` - Covers runtime wiring for stale delivery invalidation and TTY rendering guardrails.

**Documentation:**
- `packages/pi-ac-workflow/extensions/pimux/docs/protocol.md` - Documents idempotent terminal delivery semantics.
- `packages/pi-ac-workflow/extensions/pimux/docs/commands.md` - Documents terminal delivery retry/suppression and prune invalidation behavior.

## Related

- Closes #91
- **Spec**: `.specs/specs/2026/07/fix/91-pimux-terminal-event-dedupe/001-fix-pimux-terminal-event-dedupe.md`
- **Ticket**: [Issue 91](https://github.com/WaterplanAI/agentic-config/issues/91)

Generated with pi