### PR TITLE
fix(pimux): normalize closeout reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to agentic-config.
 
 ## [Unreleased]
 
+### Fixed
+
+- `pi-ac-workflow`: normalize `pimux` closeout report artifacts so parent deliveries always expose a Table of Contents and Executive Summary, even when a child only supplies a plain summary.
+
 ## [0.3.2] - 2026-07-06
 
 ### Changed

--- a/packages/pi-ac-workflow/extensions/pimux/bridge.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/bridge.ts
@@ -369,14 +369,78 @@ export async function nextBridgeReportNumber(bridgeDir: string): Promise<number>
 	});
 }
 
+function formatReportKind(kind: ReportParentKind): string {
+	return kind.charAt(0).toUpperCase() + kind.slice(1);
+}
+
+function hasTableOfContentsSection(content: string): boolean {
+	return /^##\s+Table of Contents\b/im.test(content);
+}
+
+function hasExecutiveSummarySection(content: string): boolean {
+	return /^##\s+Executive Summary\b/im.test(content);
+}
+
+function resolveExecutiveSummary(kind: ReportParentKind, summary: string, markdown: string): string {
+	const trimmedSummary = summary.trim();
+	if (trimmedSummary) return trimmedSummary;
+	const extractedSummary = extractExecutiveSummary(markdown).trim();
+	if (extractedSummary && extractedSummary !== "No Executive Summary section found") return extractedSummary;
+	const trimmedMarkdown = markdown.trim();
+	if (trimmedMarkdown) return trimmedMarkdown;
+	return `${formatReportKind(kind)} report emitted without additional detail.`;
+}
+
+function defaultReportNextSteps(kind: ReportParentKind): string[] {
+	if (kind === "closeout") return ["- Parent can consume this closeout and continue orchestration."];
+	if (kind === "progress") return ["- Continue work or wait for the next progress or terminal report."];
+	if (kind === "question") return ["- Parent should answer the terminal question before expecting further progress."];
+	if (kind === "blocker") return ["- Parent should review the blocker details and choose a recovery path."];
+	return ["- Parent should review the failure details and decide whether to recover or stop."];
+}
+
+export function normalizeBridgeReportMarkdown(kind: ReportParentKind, summary: string, markdown: string): string {
+	const trimmedMarkdown = markdown.trim();
+	if (trimmedMarkdown && hasTableOfContentsSection(trimmedMarkdown) && hasExecutiveSummarySection(trimmedMarkdown)) {
+		return trimmedMarkdown;
+	}
+
+	const kindLabel = formatReportKind(kind);
+	const detailsHeading = `${kindLabel} Details`;
+	const executiveSummary = resolveExecutiveSummary(kind, summary, trimmedMarkdown);
+	return [
+		`# Pimux ${kindLabel} Report`,
+		"",
+		"## Table of Contents",
+		"- [Executive Summary](#executive-summary)",
+		"- [Next Steps](#next-steps)",
+		trimmedMarkdown ? `- [${detailsHeading}](#${kind}-details)` : undefined,
+		"",
+		"## Executive Summary",
+		executiveSummary,
+		"",
+		"### Next Steps",
+		...defaultReportNextSteps(kind),
+		trimmedMarkdown ? "" : undefined,
+		trimmedMarkdown ? `## ${detailsHeading}` : undefined,
+		trimmedMarkdown ? "" : undefined,
+		trimmedMarkdown || undefined,
+	]
+		.filter((line): line is string => line !== undefined)
+		.join("\n")
+		.trimEnd();
+}
+
 export async function writeBridgeReport(
 	bridgeDir: string,
 	kind: ReportParentKind,
 	markdown: string,
+	summary = "",
 ): Promise<{ reportPath: string; reportNumber: number }> {
 	const reportNumber = await nextBridgeReportNumber(bridgeDir);
 	const reportPath = path.join(getBridgeReportsDir(bridgeDir), `${String(reportNumber).padStart(3, "0")}-${kind}.md`);
-	await writeTextFileAtomic(reportPath, markdown.trimEnd() + "\n");
+	const normalizedMarkdown = normalizeBridgeReportMarkdown(kind, summary, markdown);
+	await writeTextFileAtomic(reportPath, normalizedMarkdown.trimEnd() + "\n");
 	return { reportPath, reportNumber };
 }
 
@@ -464,6 +528,7 @@ export function buildChildProtocol(launch: BridgeLaunchFile): string {
 		"Messaging contract:",
 		"- Keep reports bounded and decision-oriented.",
 		"- Include status, delivered work, blockers, and next recommendation in summaries.",
+		"- For closeout, include reportMarkdown with evidence and a `## Executive Summary` whenever possible; the runtime normalizes missing report structure for parent routing.",
 		"- Use requiresResponse=true on progress when the parent must answer before you can continue.",
 		launch.goal ? `Launch goal: ${launch.goal}` : `Launch goal: ${launch.promptPreview}`,
 		launch.role ? `Launch role: ${launch.role}` : undefined,

--- a/packages/pi-ac-workflow/extensions/pimux/docs/protocol.md
+++ b/packages/pi-ac-workflow/extensions/pimux/docs/protocol.md
@@ -10,6 +10,16 @@ Package-owned runtime protocol docs for the `pimux` extension command, tool, bri
 - ordinary child `progress` is notification-only unless `requiresResponse=true`
 - one hop only: L2 reports to L1, L1 reports to L0
 
+## Report shape
+
+Closeout reports must be useful from the parent delivery summary alone. The runtime now persists a closeout report artifact even when the child only provides a short summary, and normalizes saved reports so they include:
+
+- `## Table of Contents`
+- `## Executive Summary`
+- a next-step recommendation for the parent/orchestrator
+
+Children should still provide `reportMarkdown` with evidence whenever possible; normalization is a safety net, not a substitute for good closeout content.
+
 ## Authority model
 
 Only the authoritative direct child session for a bridge may call `report_parent`.

--- a/packages/pi-ac-workflow/extensions/pimux/index.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/index.ts
@@ -998,8 +998,9 @@ async function reportParent(
 		}
 	}
 	let reportPath: string | undefined;
-	if (request.reportMarkdown?.trim()) {
-		const report = await writeBridgeReport(currentEnv.bridgeDir, request.kind, request.reportMarkdown);
+	const reportMarkdown = request.reportMarkdown?.trim();
+	if (request.kind === "closeout" || reportMarkdown) {
+		const report = await writeBridgeReport(currentEnv.bridgeDir, request.kind, reportMarkdown ?? "", request.summary);
 		reportPath = report.reportPath;
 	}
 	const launch = await readBridgeLaunch(currentEnv.bridgeDir);

--- a/packages/pi-ac-workflow/extensions/pimux/launcher-exit.ts
+++ b/packages/pi-ac-workflow/extensions/pimux/launcher-exit.ts
@@ -75,14 +75,15 @@ export async function reportManagedLauncherExit(params: {
 				: undefined,
 		]
 			.filter((line): line is string => Boolean(line));
-		const { reportPath } = await writeBridgeReport(params.bridgeDir, "failure", reportLines.join("\n"));
+		const failureSummary = `${launch.agentId} exited before terminal handoff (status ${params.exitStatus})`;
+		const { reportPath } = await writeBridgeReport(params.bridgeDir, "failure", reportLines.join("\n"), failureSummary);
 		const failureEvent = await appendBridgeEvent(params.bridgeDir, {
 			launchId: launch.launchId,
 			direction: "child_to_parent",
 			type: "failure",
 			from: { agentId: launch.agentId, sessionName: launch.sessionName },
 			to: launch.parentAgentId ? { agentId: launch.parentAgentId } : undefined,
-			summary: `${launch.agentId} exited before terminal handoff (status ${params.exitStatus})`,
+			summary: failureSummary,
 			reportPath,
 		});
 		await writeBridgeEventSignal(params.bridgeDir, failureEvent, true);


### PR DESCRIPTION
## Summary

Fixes pimux closeout delivery summaries so orchestrators always receive a useful Table of Contents and Executive Summary.

- Always persist a closeout report artifact, even when the child only sends a short summary.
- Normalize saved pimux reports with TOC, Executive Summary, and next-step guidance.
- Document the closeout report shape.

### Root Cause

Closeout reports without `reportMarkdown` had no report artifact, so parent summary extraction produced missing TOC / Executive Summary evidence.

### Key Changes

**pimux runtime:**
- Add report markdown normalization in `bridge.ts`.
- Create closeout reports from summaries in `index.ts`.
- Pass launcher failure summaries into normalized reports.

**Docs:**
- Document required closeout report shape in protocol docs.

## Test Plan

- [x] `bun` smoke test for normalized report summary
- [x] `bun build` changed pimux TS entrypoints
- [x] `git diff --check`
- [x] Commit hook: `PII_AUDIT: PASS`

## Files Changed

**Runtime:**
- `packages/pi-ac-workflow/extensions/pimux/bridge.ts`
- `packages/pi-ac-workflow/extensions/pimux/index.ts`
- `packages/pi-ac-workflow/extensions/pimux/launcher-exit.ts`

**Docs:**
- `packages/pi-ac-workflow/extensions/pimux/docs/protocol.md`
- `CHANGELOG.md`

## Related

- **Spec**: `.specs/specs/2026/07/fix/pimux-closeout-report-toc-executive-summary/000-backlog.md`

Generated with pi
