### PR TITLE
fix(pi-ac-tools): restore web-search startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to agentic-config.
 ### Fixed
 
 - `pi-ac-workflow`: normalize `pimux` closeout report artifacts so parent deliveries always expose a Table of Contents and Executive Summary, even when a child only supplies a plain summary.
+- `pi-ac-tools`: restore web-search extension startup on Pi 0.80.8+ by replacing the removed `AuthStorage` API with an extension-owned, owner-only Brave key file; keys previously saved through the old integration must be saved once with `/web-search-setup`.
 
 ## [0.3.2] - 2026-07-06
 

--- a/packages/pi-ac-tools/README.md
+++ b/packages/pi-ac-tools/README.md
@@ -67,7 +67,8 @@ The `say` and `web-search` extensions are agentic-config package extensions. The
 - package-local `web-search` extension under `extensions/web-search/`
 - exports the `web_search` grounded web research tool plus `/web-search-status`, `/web-search-lock`, `/web-search-setup`, `/web-search-auth`, and `/web-search-backend`
 - `/web-search-backend status|brave-search|codex-search|claude-search` persists the selected default backend and runs it first before falling back through the remaining backends
-- Brave Search requires `BRAVE_SEARCH_API_KEY` or the Pi auth store via `/web-search-setup`; Codex and Claude backends use the corresponding Pi-configured providers when available
+- Brave Search requires `BRAVE_SEARCH_API_KEY` or the extension-owned, owner-only auth file configured via `/web-search-setup`; Codex and Claude backends use the corresponding Pi-configured providers when available
+- Keys previously saved under the removed Pi `AuthStorage` integration must be saved once in the extension-owned file with `/web-search-setup`
 
 ### Deferred surface
 - none

--- a/packages/pi-ac-tools/extensions/web-search/auth.ts
+++ b/packages/pi-ac-tools/extensions/web-search/auth.ts
@@ -1,11 +1,12 @@
-import { join } from "node:path";
-import { AuthStorage, getAgentDir } from "@earendil-works/pi-coding-agent";
+import { randomUUID } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
-import type { RuntimeState } from "./types.js";
+import type { BraveAuthStorage, RuntimeState } from "./types.js";
 
-export const BRAVE_AUTH_PROVIDER = "web-search-brave";
 export const BRAVE_ENV_VAR = "BRAVE_SEARCH_API_KEY";
-export const BRAVE_AUTH_PATH = join(getAgentDir(), "auth.json");
+export const BRAVE_AUTH_PATH = join(getAgentDir(), "web-search", "auth.json");
 
 export interface BraveAuthStatus {
   envConfigured: boolean;
@@ -13,13 +14,65 @@ export interface BraveAuthStatus {
   activeSource: "env" | "auth.json" | "none";
 }
 
-export function createAuthStorage(): AuthStorage {
-  return AuthStorage.create();
+interface BraveAuthFile {
+  api_key?: unknown;
 }
 
-export function getBraveAuthStatus(authStorage: AuthStorage): BraveAuthStatus {
+class FileBraveAuthStorage implements BraveAuthStorage {
+  private apiKey: string | undefined;
+
+  constructor(private readonly path: string) {
+    this.reload();
+  }
+
+  reload(): void {
+    if (!existsSync(this.path)) {
+      this.apiKey = undefined;
+      return;
+    }
+
+    const parsed = JSON.parse(readFileSync(this.path, "utf8")) as BraveAuthFile;
+    this.apiKey = normalizeSecret(parsed.api_key);
+  }
+
+  hasApiKey(): boolean {
+    return this.apiKey !== undefined;
+  }
+
+  getApiKey(): string | undefined {
+    return this.apiKey;
+  }
+
+  setApiKey(apiKey: string): void {
+    const directory = dirname(this.path);
+    const tempPath = join(directory, `.auth-${process.pid}-${randomUUID()}.tmp`);
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+    chmodSync(directory, 0o700);
+
+    try {
+      const payload = `${JSON.stringify({ api_key: apiKey }, null, 2)}\n`;
+      writeFileSync(tempPath, payload, { encoding: "utf8", flag: "wx", mode: 0o600 });
+      renameSync(tempPath, this.path);
+      chmodSync(this.path, 0o600);
+      this.apiKey = apiKey;
+    } finally {
+      rmSync(tempPath, { force: true });
+    }
+  }
+
+  clear(): void {
+    rmSync(this.path, { force: true });
+    this.apiKey = undefined;
+  }
+}
+
+export function createAuthStorage(): BraveAuthStorage {
+  return new FileBraveAuthStorage(BRAVE_AUTH_PATH);
+}
+
+export function getBraveAuthStatus(authStorage: BraveAuthStorage): BraveAuthStatus {
   const envConfigured = Boolean(normalizeSecret(process.env[BRAVE_ENV_VAR]));
-  const authConfigured = authStorage.has(BRAVE_AUTH_PROVIDER);
+  const authConfigured = authStorage.hasApiKey();
 
   return {
     envConfigured,
@@ -29,7 +82,7 @@ export function getBraveAuthStatus(authStorage: AuthStorage): BraveAuthStatus {
 }
 
 export async function resolveBraveApiKey(
-  authStorage: AuthStorage,
+  authStorage: BraveAuthStorage,
   ctx: ExtensionContext | undefined,
   runtime: RuntimeState,
 ): Promise<string | undefined> {
@@ -40,7 +93,7 @@ export async function resolveBraveApiKey(
     return envKey;
   }
 
-  const savedKey = normalizeSecret(await authStorage.getApiKey(BRAVE_AUTH_PROVIDER, { includeFallback: false }));
+  const savedKey = normalizeSecret(authStorage.getApiKey());
   if (savedKey) {
     return savedKey;
   }
@@ -52,32 +105,29 @@ export async function resolveBraveApiKey(
     return envKeyAfterPrompt;
   }
 
-  return normalizeSecret(await authStorage.getApiKey(BRAVE_AUTH_PROVIDER, { includeFallback: false }));
+  return normalizeSecret(authStorage.getApiKey());
 }
 
-export function setBraveApiKey(authStorage: AuthStorage, apiKey: string): void {
+export function setBraveApiKey(authStorage: BraveAuthStorage, apiKey: string): void {
   const normalized = normalizeSecret(apiKey);
   if (!normalized) {
     throw new Error("Brave Search API key must not be empty.");
   }
 
-  authStorage.set(BRAVE_AUTH_PROVIDER, {
-    type: "api_key",
-    key: normalized,
-  });
+  authStorage.setApiKey(normalized);
 }
 
-export function clearBraveApiKey(authStorage: AuthStorage): void {
-  authStorage.remove(BRAVE_AUTH_PROVIDER);
+export function clearBraveApiKey(authStorage: BraveAuthStorage): void {
+  authStorage.clear();
 }
 
-export function formatBraveAuthStatus(authStorage: AuthStorage): string {
+export function formatBraveAuthStatus(authStorage: BraveAuthStorage): string {
   const status = getBraveAuthStatus(authStorage);
 
   return [
     "web-search auth",
     `- ${BRAVE_ENV_VAR}: ${status.envConfigured ? "configured" : "not configured"}`,
-    `- ${BRAVE_AUTH_PATH} (${BRAVE_AUTH_PROVIDER}): ${status.authConfigured ? "configured" : "not configured"}`,
+    `- ${BRAVE_AUTH_PATH}: ${status.authConfigured ? "configured" : "not configured"}`,
     `- active source: ${status.activeSource}`,
   ].join("\n");
 }
@@ -85,18 +135,17 @@ export function formatBraveAuthStatus(authStorage: AuthStorage): string {
 export function missingBraveKeySetupHint(): string {
   return [
     "Brave Search API key is not configured.",
-    `Set ${BRAVE_ENV_VAR} or store the key in ${BRAVE_AUTH_PATH} under ${BRAVE_AUTH_PROVIDER}.`,
-    "Use /web-search-setup for guided setup.",
+    `Set ${BRAVE_ENV_VAR} or use /web-search-setup to save the key in ${BRAVE_AUTH_PATH}.`,
   ].join(" ");
 }
 
 export async function runInteractiveBraveSetup(
-  authStorage: AuthStorage,
+  authStorage: BraveAuthStorage,
   ctx: ExtensionContext,
   runtime: RuntimeState,
 ): Promise<string> {
   const status = getBraveAuthStatus(authStorage);
-  const saveLabel = status.authConfigured ? "Replace saved key in Pi auth store" : "Save key in Pi auth store";
+  const saveLabel = status.authConfigured ? "Replace saved key" : "Save key";
   const choice = await ctx.ui.select("Configure Brave Search", [
     saveLabel,
     "Use environment variable instead",
@@ -128,11 +177,11 @@ export async function runInteractiveBraveSetup(
   }
 
   setBraveApiKey(authStorage, normalized);
-  return `Saved Brave Search API key in ${BRAVE_AUTH_PATH}. This file uses Pi's auth store and is kept outside the project.`;
+  return `Saved Brave Search API key in ${BRAVE_AUTH_PATH}. The file is kept outside projects with owner-only permissions.`;
 }
 
 async function maybePromptForBraveSetup(
-  authStorage: AuthStorage,
+  authStorage: BraveAuthStorage,
   ctx: ExtensionContext | undefined,
   runtime: RuntimeState,
 ): Promise<void> {

--- a/packages/pi-ac-tools/extensions/web-search/index.ts
+++ b/packages/pi-ac-tools/extensions/web-search/index.ts
@@ -3,7 +3,6 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import {
   BRAVE_AUTH_PATH,
-  BRAVE_AUTH_PROVIDER,
   BRAVE_ENV_VAR,
   clearBraveApiKey,
   createAuthStorage,
@@ -65,14 +64,6 @@ export default function webSearchExtension(pi: ExtensionAPI): void {
   });
 
   pi.on("session_start", async (_event, ctx) => {
-    await resetSessionState(ctx);
-  });
-
-  pi.on("session_switch", async (_event, ctx) => {
-    await resetSessionState(ctx);
-  });
-
-  pi.on("session_fork", async (_event, ctx) => {
     await resetSessionState(ctx);
   });
 
@@ -150,7 +141,7 @@ export default function webSearchExtension(pi: ExtensionAPI): void {
 
       if (!ctx.hasUI) {
         ctx.ui.notify(
-          `No interactive UI is available. Set ${BRAVE_ENV_VAR} before starting pi, or store the key in ${BRAVE_AUTH_PATH} under ${BRAVE_AUTH_PROVIDER}.`,
+          `No interactive UI is available. Set ${BRAVE_ENV_VAR} before starting pi, or use /web-search-setup in interactive mode to save the key in ${BRAVE_AUTH_PATH}.`,
           "info",
         );
         return;

--- a/packages/pi-ac-tools/extensions/web-search/types.ts
+++ b/packages/pi-ac-tools/extensions/web-search/types.ts
@@ -1,5 +1,3 @@
-import type { AuthStorage } from "@earendil-works/pi-coding-agent";
-
 export const BACKEND_NAMES = ["brave-search", "codex-search", "claude-search"] as const;
 export type BackendName = (typeof BACKEND_NAMES)[number];
 
@@ -114,6 +112,14 @@ export interface BraveUsageState {
   requests_used_this_month: number;
 }
 
+export interface BraveAuthStorage {
+  reload(): void;
+  hasApiKey(): boolean;
+  getApiKey(): string | undefined;
+  setApiKey(apiKey: string): void;
+  clear(): void;
+}
+
 export interface SessionStats {
   tool_calls_total: number;
   cache_hits_total: number;
@@ -127,7 +133,7 @@ export interface RuntimeState {
   inFlight: Map<string, Promise<ToolResultPayload>>;
   lockState: LockState;
   stats: SessionStats;
-  authStorage: AuthStorage;
+  authStorage: BraveAuthStorage;
   braveSetupPromptShown: boolean;
   braveUsage: BraveUsageState;
   braveLane: Promise<void>;


### PR DESCRIPTION
## Summary

Restore the web-search extension on Pi 0.80.8+ by replacing the removed `AuthStorage` API with extension-owned Brave key storage.

### Root Cause
Pi no longer exports the `AuthStorage` API used during extension startup.

### Key Changes
- Store Brave keys in an owner-only file with atomic writes.
- Remove obsolete session event handlers.
- Document the one-time key migration step.

## Test Plan

- [ ] Start Pi 0.80.8+ and verify web-search loads.
- [ ] Save, resolve, replace, and clear a Brave key.
- [ ] Confirm directory and file permissions are `0700` and `0600`.

## Files Changed

- `packages/pi-ac-tools/extensions/web-search/` - Auth storage and runtime compatibility.
- `packages/pi-ac-tools/README.md` and `CHANGELOG.md` - Migration documentation.

## Related

- **Spec**: N/A

Generated with pi